### PR TITLE
Develop

### DIFF
--- a/api/settings.js
+++ b/api/settings.js
@@ -196,6 +196,19 @@ function changeSettings($, req, res, next) {
 
         if (typeof value === 'undefined') continue;
 
+        if (value === '' || value === null) {
+          switch (fieldName) {
+            case 'Emailhash':
+            case 'WalletLocator':
+              value = '0';
+              break;
+
+            case 'WalletSize':
+              value = 0;
+              break;
+          }
+        }
+
         if (field.encoding === 'hex') {
           if (field.length) {
             // Fixed length


### PR DESCRIPTION
- Automatically pad fixed-length fields
- Unset all fields with empty string or null
- Don't wait for AccountSet transaction to validate
