### PR TITLE
typo fixes

### DIFF
--- a/lib/db-interface.js
+++ b/lib/db-interface.js
@@ -280,7 +280,7 @@ DatabaseInterface.prototype.getFailedTransactions = function(opts, callback) {
 DatabaseInterface.prototype.moveValidatedTransactionsToPermanentTable = function(callback) {
   var self = this;
 
-  function findOrcreate(num_moved, entry, async_callback) {
+  function findOrCreate(num_moved, entry, async_callback) {
     self.models.client_resource_id_records.findOrCreate({
       source_account:     entry.values.source_account,
       type:               entry.values.type,
@@ -298,7 +298,7 @@ DatabaseInterface.prototype.moveValidatedTransactionsToPermanentTable = function
       // Once the transaction has been saved to the client_resource_id_records table
       // it may be deleted from the outgoing_transactions table
       // if (entry.created) {
-      outgoing_transactions_entry.destroy().complete(function(err) {
+      entry.destroy().complete(function(err) {
         if (err) {
           async_callback(err);
         } else {


### PR DESCRIPTION
while doing a deployment of ripple-rest, I found these typos that resulted in some bugs with payments processing. I've fixed them and ran the tests to ensure they're not breaking anything.
