### PR TITLE
[TEST] Accurately report coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "grunt-simple-mocha": "*",
     "istanbul": "^0.2.10",
     "mocha": "*",
+    "require-directory": "^1.2.0",
     "sinon": "~1.10.0",
     "sinon-chai": "~2.5.0"
   },

--- a/test/instrument-all-source-files.js
+++ b/test/instrument-all-source-files.js
@@ -1,0 +1,7 @@
+// Require all important source files so they 
+// are included in the code coverage statistics
+var requireDirectory = require('require-directory');
+requireDirectory(module, __dirname + '/../api');
+requireDirectory(module, __dirname + '/../db');
+requireDirectory(module, __dirname + '/../lib');
+require('../server');


### PR DESCRIPTION
Istanbul only counts files that are included when the tests are run. This additional script ensures that all of the source files are included so that the coverage statistics are accurate.
