### PR TITLE
add invoiceID in transaction

### DIFF
--- a/api/payments.js
+++ b/api/payments.js
@@ -271,7 +271,7 @@ function paymentToTransaction(payment, callback) {
     
     // invoice_id  Because transaction_data is a object,  transaction.payment function is ignored invoiceID
     if (payment.invoice_id) {
-      transaction.invoiceID = payment.invoice_id;
+      transaction.invoiceID(payment.invoice_id);
     }
 
     transaction.payment(transaction_data);


### PR DESCRIPTION
Because transaction_data is a object,  transaction.payment function is ignored invoiceID
