### PR TITLE
[FIX] Check that tx.meta exists before accessing

### DIFF
--- a/api/payments.js
+++ b/api/payments.js
@@ -929,7 +929,7 @@ function parsePaymentFromTx(tx, options) {
           'passthrough')) :
       ''),
     state: tx.state || tx.meta ? (tx.meta.TransactionResult === 'tesSUCCESS' ? 'validated' : 'failed') : '',
-    result: tx.meta.TransactionResult || '',
+    result: tx.meta ? tx.meta.TransactionResult : '',
     ledger: '' + (tx.inLedger || tx.ledger_index),
     hash: tx.hash || '',
     timestamp: (tx.date ? new Date(ripple.utils.toTimestamp(tx.date)).toISOString() : ''),


### PR DESCRIPTION
Previous to this tweak, the ripple-rest server would crash when processing a payment confirmation request immediately after the payment was submitted.
