### PR TITLE
[FIX] Allow browser-based client to make POST to ripple-rest server

### DIFF
--- a/lib/express_app.js
+++ b/lib/express_app.js
@@ -61,7 +61,7 @@ app.param('destination_account', rippleAddressParam('destination account'));
 
 app.all('*', function(req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Headers', 'X-Requested-With');
+  res.header('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type');
   next();
 });
 


### PR DESCRIPTION
Fixes http POST /v1/payments request error from browser-based clients (namely $http post in angularjs):

"XMLHttpRequest cannot load http://ripple-rest-api-server-endpoint. Request header field Content-Type is not allowed by Access-Control-Allow-Headers."
