### PR TITLE
[DOC] fix v1/status to v1/server in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Note that if `npm install` fails because the user running it does not have suffi
 2. `cp config-example.json config.json` and configure DATABASE_URL appropriately
 3. Run `npm install` to install the dependencies and setup the database
 4. Run `node server.js` to start the server
-5. Visit `http://localhost:5990/api/v1/status` in your browser to confirm that the server is up and running
+5. Visit `http://localhost:5990/api/v1/server` in your browser to confirm that the server is up and running
 
 #### On Mac OSX
 


### PR DESCRIPTION
the readme has the call v1/status instead of v1/server
