### PR TITLE
[FEATURE] Balances|Trustlines|Orders: Return ledger_index, use last validated ledger by default (RLJS-127)

### DIFF
--- a/api/orders.js
+++ b/api/orders.js
@@ -7,6 +7,7 @@ var SubmitTransactionHooks = require('./../lib/submit_transaction_hooks.js');
 var respond                = require('./../lib/response-handler.js');
 var utils                  = require('./../lib/utils');
 var errors                 = require('./../lib/errors.js');
+var validator             = require('./../lib/schema-validator.js');
 
 const InvalidRequestError   = errors.InvalidRequestError;
 
@@ -34,6 +35,16 @@ function getOrders(request, response, next) {
       orders.marker = result.marker;
     }
 
+    if (result.limit) {
+      orders.limit = result.limit;
+    }
+
+    if (result.ledger_index) {
+      orders.ledger = result.ledger_index;
+    }
+
+    orders.validated = result.validated;
+
     orders.orders = result.offers;
 
     respond.success(response, orders);
@@ -56,8 +67,8 @@ function getOrders(request, response, next) {
     var promise = new Promise(function(resolve, reject) {
       var accountOrdersRequest;
       var marker = request.query.marker;
-      var limit = /^[0-9]*$/.test(request.query.limit) ? Number(request.query.limit) : void(0);
-      var ledger = /^[0-9]*$/.test(request.query.ledger) ? Number(request.query.ledger) : void(0);
+      var limit = validator.isValid(request.query.limit, 'UINT32') ? Number(request.query.limit) : void(0);
+      var ledger = validator.isValid(request.query.ledger, 'UINT32') ? Number(request.query.ledger) : 'validated';
 
       accountOrdersRequest = remote.requestAccountOffers({
         account: options.account,

--- a/api/trustlines.js
+++ b/api/trustlines.js
@@ -81,8 +81,8 @@ function getTrustLines(request, response, next) {
   function getAccountLines(callback) {
     var accountLinesRequest;
     var marker = request.query.marker;
-    var limit = /^[0-9]*$/.test(request.query.limit) ? Number(request.query.limit) : void(0);
-    var ledger = /^[0-9]*$/.test(request.query.ledger) ? Number(request.query.ledger) : void(0);
+    var limit = validator.isValid(request.query.limit, 'UINT32') ? Number(request.query.limit) : void(0);
+    var ledger = validator.isValid(request.query.ledger, 'UINT32') ? Number(request.query.ledger) : 'validated';
 
     try {
       accountLinesRequest = remote.requestAccountLines({
@@ -126,6 +126,12 @@ function getTrustLines(request, response, next) {
       if (result.limit) {
         trustlines.limit = result.limit;
       }
+
+      if (result.ledger_index) {
+        trustlines.ledger = result.ledger_index;
+      }
+
+      trustlines.validated = result.validated
 
       trustlines.trustlines = lines;
 

--- a/test/_payments-test.js
+++ b/test/_payments-test.js
@@ -226,7 +226,8 @@ suite('payments', function() {
         delete data.id;
         assert.deepEqual(data, {
           command: 'account_info',
-          account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U'
+          account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
+          ledger_index: 'validated'
         });
         orderlist.mark('account_info');
     };
@@ -235,7 +236,8 @@ suite('payments', function() {
         delete data.id;
         assert.deepEqual(data, {
           command: 'account_lines',
-          account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U'
+          account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
+          ledger_index: 'validated'
         });
         orderlist.mark('account_lines');
     };
@@ -522,7 +524,8 @@ suite('payments', function() {
       delete data.id;
       assert.deepEqual(data, {
         command: 'account_info',
-        account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5'
+        account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5',
+        ledger_index: 'validated'
       });
       orderlist.mark('account_info');
     };
@@ -531,7 +534,8 @@ suite('payments', function() {
       delete data.id;
       assert.deepEqual(data, {
         command: 'account_lines',
-        account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5'
+        account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5',
+        ledger_index: 'validated'
       });
       orderlist.mark('account_lines');
     };

--- a/test/fixtures/balances.js
+++ b/test/fixtures/balances.js
@@ -1,10 +1,17 @@
+var _ = require('lodash');
 var addresses = require('./addresses');
 
 module.exports.requestPath = function(address, params) {
   return '/v1/accounts/' + address + '/balances' + ( params || '' );
 };
 
-module.exports.accountInfoResponse = function(request) {
+module.exports.accountInfoResponse = function(request, options) {
+  options = options || {};
+
+  _.defaults(options, {
+    validated: true
+  });
+
   return JSON.stringify({
     id: request.id,
     status: 'success',
@@ -26,7 +33,8 @@ module.exports.accountInfoResponse = function(request) {
         index: '396400950EA27EB5710C0D5BE1D2B4689139F168AC5D07C13B8140EC3F82AE71',
         urlgravatar: 'http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8'
       },
-      ledger_current_index: 6614628
+      ledger_index: options.ledger,
+      validated: options.validated
     }
   });
 };
@@ -53,6 +61,10 @@ module.exports.accountNotFoundResponse = function(request) {
 module.exports.accountLinesResponse = function(request, options) {
   var options = options || {};
 
+  _.defaults(options, {
+    validated: true
+  });
+
   return JSON.stringify({
     id: request.id,
     status: 'success',
@@ -61,6 +73,8 @@ module.exports.accountLinesResponse = function(request, options) {
       account: addresses.VALID,
       marker: options.marker,
       limit: request.limit,
+      ledger_index: options.ledger,
+      validated: options.validated,
       lines: [
         {
         account: 'r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z',
@@ -299,13 +313,23 @@ module.exports.accountLinesResponse = function(request, options) {
   });
 };
 
-module.exports.accountLinesCounterpartyResponse = function(request) {
+module.exports.accountLinesCounterpartyResponse = function(request, options) {
+  var options = options || {};
+
+  _.defaults(options, {
+    validated: true
+  });
+
   return JSON.stringify({
     id: request.id,
     status: 'success',
     type: 'response',
     result: {
       account: addresses.VALID,
+      marker: options.marker,
+      limit: request.limit,
+      ledger_index: options.ledger,
+      validated: options.validated,
       lines: [
       {
         account: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
@@ -374,10 +398,16 @@ module.exports.accountLinesNoCounterpartyResponse = function(request) {
 module.exports.RESTAccountBalancesResponse = function(options) {
   options = options || {};
 
+  _.defaults(options, {
+    validated: true
+  });
+
   return JSON.stringify({
     success: true,
     marker: options.marker,
     limit: options.limit,
+    ledger: options.ledger,
+    validated: options.validated,
     balances: [
       { value: '922.913243', currency: 'XRP', counterparty: '' },
       { value: '0', currency: 'ASP', counterparty: 'r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z' },
@@ -408,45 +438,93 @@ module.exports.RESTAccountBalancesResponse = function(options) {
   });
 };
 
-module.exports.RESTAccountBalancesUSDResponse = JSON.stringify({
-  success: true,
-  balances: [
-    { value: '2.497605752725159', currency: 'USD', counterparty: 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q' },
-    { value: '0', currency: 'USD', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
-    { value: '1', currency: 'USD', counterparty: 'rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun' },
-    { value: '0', currency: 'USD', counterparty: 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X' },
-    { value: '35', currency: 'USD', counterparty: 'rfF3PNkwkq1DygW2wum2HK3RGfgkJjdPVD' },
-    { value: '0', currency: 'USD', counterparty: 'rE6R3DWF9fBD7CyiQciePF9SqK58Ubp8o2' },
-    { value: '0', currency: 'USD', counterparty: 'rEhDDUUNxpXgEHVJtC2cjXAgyx5VCFxdMF' }
-  ]
-});
+module.exports.RESTAccountBalancesUSDResponse = function(options) {
+  options = options || {};
 
-module.exports.RESTAccountBalancesXRPResponse = JSON.stringify({
-  success: true,
-  balances: [
-    { value: '922.913243', currency: 'XRP', counterparty: '' }
-  ]
-});
+  _.defaults(options, {
+    validated: true
+  });
 
-module.exports.RESTAccountBalancesCounterpartyResponse = JSON.stringify({
-  success: true,
-  balances: [
-    { value: '0.3488146605801446', currency: 'CHF', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
-    { value: '2.114103174931847', currency: 'BTC', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
-    { value: '0', currency: 'USD', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
-    { value: '7.292695098901099', currency: 'JPY', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
-    { value: '12.41688780720394', currency: 'EUR', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' }
-  ]
-});
+  return JSON.stringify({
+
+    success: true,
+    marker: options.marker,
+    limit: options.limit,
+    ledger: options.ledger,
+    validated: options.validated,
+    balances: [
+      { value: '2.497605752725159', currency: 'USD', counterparty: 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q' },
+      { value: '0', currency: 'USD', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
+      { value: '1', currency: 'USD', counterparty: 'rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun' },
+      { value: '0', currency: 'USD', counterparty: 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X' },
+      { value: '35', currency: 'USD', counterparty: 'rfF3PNkwkq1DygW2wum2HK3RGfgkJjdPVD' },
+      { value: '0', currency: 'USD', counterparty: 'rE6R3DWF9fBD7CyiQciePF9SqK58Ubp8o2' },
+      { value: '0', currency: 'USD', counterparty: 'rEhDDUUNxpXgEHVJtC2cjXAgyx5VCFxdMF' }
+    ]
+  });
+};
+
+module.exports.RESTAccountBalancesXRPResponse = function(options) {
+  options = options || {};
+
+  _.defaults(options, {
+    validated: true
+  });
+
+  return JSON.stringify({
+    success: true,
+    limit: options.limit,
+    ledger: options.ledger,
+    validated: options.validated,
+    balances: [
+      { value: '922.913243', currency: 'XRP', counterparty: '' }
+    ]
+  });
+};
+
+module.exports.RESTAccountBalancesCounterpartyResponse = function(options) {
+  options = options || {};
+
+  _.defaults(options, {
+    validated: true
+  });
+
+  return JSON.stringify({
+    success: true,
+    marker: options.marker,
+    limit: options.limit,
+    ledger: options.ledger,
+    validated: options.validated,
+    balances: [
+      { value: '0.3488146605801446', currency: 'CHF', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
+      { value: '2.114103174931847', currency: 'BTC', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
+      { value: '0', currency: 'USD', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
+      { value: '7.292695098901099', currency: 'JPY', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' },
+      { value: '12.41688780720394', currency: 'EUR', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' }
+    ]
+  });
+};
 
 module.exports.RESTAccountBalancesNoCounterpartyResponse = JSON.stringify({
   success: true,
   balances: [ ]
 });
 
-module.exports.RESTAccountBalancesCounterpartyCurrencyResponse = JSON.stringify({
-  success: true,
-  balances: [
-    { value: '12.41688780720394', currency: 'EUR', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' }
-  ]
-});
+module.exports.RESTAccountBalancesCounterpartyCurrencyResponse = function(options) {
+  options = options || {};
+
+  _.defaults(options, {
+    validated: true
+  });
+
+  return JSON.stringify({
+    success: true,
+    marker: options.marker,
+    limit: options.limit,
+    ledger: options.ledger,
+    validated: options.validated,
+    balances: [
+      { value: '12.41688780720394', currency: 'EUR', counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' }
+    ]
+  });
+};

--- a/test/fixtures/orders.js
+++ b/test/fixtures/orders.js
@@ -46,8 +46,10 @@ module.exports.order = function(options) {
 
 module.exports.accountOrdersResponse = function(request, options) {
   options = options || {};
+
   _.defaults(options, {
-    account: addresses.VALID
+    account: addresses.VALID,
+    validated: true
   });
 
   return JSON.stringify({
@@ -55,7 +57,8 @@ module.exports.accountOrdersResponse = function(request, options) {
     "result": {
       "account": options.account,
       "marker": options.marker,
-      "ledger_index": 9941609,
+      "limit": options.limit,
+      "ledger_index": options.ledger,
       "offers": [
         {
           "flags": 0,
@@ -288,7 +291,7 @@ module.exports.accountOrdersResponse = function(request, options) {
           }
         }
       ],
-      "validated": false
+      "validated": options.validated
     },
     "status": "success",
     "type": "response"
@@ -693,9 +696,16 @@ module.exports.unfundedOrderFinalizedResponse = function(options) {
 module.exports.RESTAccountOrdersResponse = function(options) {
   options = options || {};
 
+  _.defaults(options, {
+    validated: true
+  });
+
   return JSON.stringify({
     success: true,
     marker: options.marker,
+    limit: options.limit,
+    ledger: options.ledger,
+    validated: options.validated,
     orders: [
       {
         "flags": 0,

--- a/test/fixtures/trustlines.js
+++ b/test/fixtures/trustlines.js
@@ -7,6 +7,10 @@ module.exports.requestPath = function(address, params) {
 module.exports.accountLinesResponse = function(request, options) {
   options = options || {};
 
+  _.defaults(options, {
+    validated: true
+  });
+
   return JSON.stringify({
     id: request.id,
     status: 'success',
@@ -15,6 +19,8 @@ module.exports.accountLinesResponse = function(request, options) {
       account: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
       marker: options.marker,
       limit: request.limit,
+      ledger_index: options.ledger,
+      validated: options.validated,
       lines: [
         {
         account: 'r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z',
@@ -258,10 +264,17 @@ module.exports.accountLinesResponse = function(request, options) {
 module.exports.RESTAccountTrustlinesResponse = function(options) {
   options = options || {};
 
+  _.defaults(options, {
+    validated: true
+  });
+
+
   return JSON.stringify({
     success: true,
     marker: options.marker,
     limit: options.limit,
+    ledger: options.ledger,
+    validated: options.validated,
     trustlines: [
       { account: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
         counterparty: 'r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z',

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -104,5 +104,6 @@ module.exports = {
   checkHeaders: checkHeaders,
   checkBody: checkBody,
   generateHash: generateHash,
-  loadArguments: loadArguments
+  loadArguments: loadArguments,
+  generateHash: generateHash
 };


### PR DESCRIPTION
Also, returns `validated` key as a boolean (from the rippled response)
