### PR TITLE
Add code to allow rippled in standalone mode and not having a recently closed ledger

### DIFF
--- a/lib/server-lib.js
+++ b/lib/server-lib.js
@@ -43,6 +43,12 @@ function isConnected(remote) {
     // transactions
     return false;
   }
+  
+  if (remote._stand_alone){
+    // If rippled is in standalone mode we can assume there will not be a 
+    // ledger close within 30 seconds.  
+    return true;
+  }
 
   var server = remote.getServer();
   return server && (Date.now() - server._lastLedgerClose) <= CONNECTION_TIMEOUT;


### PR DESCRIPTION
This will probably be rejected but I wanted to try a pull request anyway and get a discussion going.  When running rippled in standalone mode you have to manual advance the ledger, so unless you manually advance the ledger (30 seconds) before every api call you well get a network error.  This isn't very useful to someone using ripple-rest to develop software using ripple-rest when in standalone mode.  If someone is connecting to a standalone server I think it can be assumed that they know they will not have an up to date ledger and will have to manual advance the ledger to access any transactions in the open ledger.

I propose that we check if the server in standalone mode and if true we ignore the time of the last closed ledger.  It might be good to include "stand_alone" : true in the json response but I don't think that should be required.