### PR TITLE
Check for rippled in standalone mode before returning false on lastLedgerClose check

### DIFF
--- a/lib/server-lib.js
+++ b/lib/server-lib.js
@@ -43,9 +43,17 @@ function isConnected(remote) {
     // transactions
     return false;
   }
-
+  
   var server = remote.getServer();
-  return server && (Date.now() - server._lastLedgerClose) <= CONNECTION_TIMEOUT;
+  if (!server) return false;
+
+  if (remote._stand_alone){
+    // If rippled is in standalone mode we can assume there will not be a 
+    // ledger close within 30 seconds.  
+    return true;
+  }
+
+  return (Date.now() - server._lastLedgerClose) <= CONNECTION_TIMEOUT;
 };
 
 /**


### PR DESCRIPTION
This is a new PR replacing https://github.com/ripple/ripple-rest/pull/253.  I changed the order so server was checked before checking remote._stand_alone then checking if server._lastLedgerClose was less then 30 seconds.  Below is my original PR comment.

When running rippled in standalone mode you have to manual advance the ledger, so unless you manually advance the ledger (30 seconds) before every api call you well get a network error. This isn't very useful to someone using ripple-rest to develop software using ripple-rest when in standalone mode. If someone is connecting to a standalone server I think it can be assumed that they know they will not have an up to date ledger and will have to manual advance the ledger to access any transactions in the open ledger.

I propose that we check if the server in standalone mode and if true we ignore the time of the last closed ledger.