### PR TITLE
[BUG] Balances: Allow hex currencies (RLJS-168)

### DIFF
--- a/api/balances.js
+++ b/api/balances.js
@@ -55,7 +55,7 @@ function getBalances(request, response, next) {
     if (options.counterparty && !ripple.UInt160.is_valid(options.counterparty)) {
       return Promise.reject(new InvalidRequestError('Parameter is not a valid Ripple address: counterparty'));
     }
-    if (options.currency && !/^[A-Z0-9]{3}$/.test(options.currency)) {
+    if (options.currency && !validator.isValid(options.currency, 'Currency')) {
       return Promise.reject(new InvalidRequestError('Parameter is not a valid currency: currency'));
     }
 


### PR DESCRIPTION
Hex currencies were returning an error:


`// GET https://api.ripple.com/v1/accounts/rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD/balances?currency=0000000000000000000000000000000000000000`

```
{
  "success": false,
  "error_type": "invalid_request",
  "error": "restINVALID_PARAMETER",
  "message": "Parameter is not a valid currency: currency"
}
```