### PR TITLE
[BUG] Correctly validate RippleAddress and remove schema validator (RLJS-169)

### DIFF
--- a/api/payments.js
+++ b/api/payments.js
@@ -100,11 +100,11 @@ function submitPayment(request, response, next) {
       return callback(new InvalidRequestError('Invalid parameter: client_resource_id. Must be a string of ASCII-printable characters. Note that 256-bit hex strings are disallowed because of the potential confusion with transaction hashes.'));
     }
 
-    if (!validator.isValid(payment.source_account, 'RippleAddress')) {
+    if (!ripple.UInt160.is_valid(payment.source_account)) {
       return callback(new InvalidRequestError('Invalid parameter: source_account. Must be a valid Ripple address'));
     }
 
-    if (!validator.isValid(payment.destination_account, 'RippleAddress')) {
+    if (!ripple.UInt160.is_valid(payment.destination_account)) {
       return callback(new InvalidRequestError('Invalid parameter: destination_account. Must be a valid Ripple address'));
     }
     // Tags
@@ -538,12 +538,12 @@ function getPathFind(request, response, next) {
     issuer:   (destinationAmountArray.length >= 3 ? destinationAmountArray[2] : '')
   };
 
-  if (!validator.isValid(params.source_account, 'RippleAddress')) {
+  if (!ripple.UInt160.is_valid(params.source_account)) {
     next(new InvalidRequestError('Invalid parameter: source_account. Must be a valid Ripple address'));
     return;
   }
 
-  if (!validator.isValid(params.destination_account, 'RippleAddress')) {
+  if (!ripple.UInt160.is_valid(params.destination_account)){
     next(new InvalidRequestError('Invalid parameter: destination_account. Must be a valid Ripple address'));
     return;
   }
@@ -569,7 +569,7 @@ function getPathFind(request, response, next) {
           currency: currencyIssuerArray[0],
           issuer: currencyIssuerArray[1]
         };
-        if (validator.isValid(currencyObject.currency, 'Currency') && validator.isValid(currencyObject.issuer, 'RippleAddress')) {
+        if (validator.isValid(currencyObject.currency, 'Currency') && ripple.UInt160.is_valid(currencyObject.issuer)) {
           params.source_currencies.push(currencyObject);
         } else {
           next(new InvalidRequestError('Invalid parameter: source_currencies. Must be a list of valid currencies'));

--- a/api/transactions.js
+++ b/api/transactions.js
@@ -235,7 +235,7 @@ function getTransaction(account, identifier, callback) {
   async.waterfall(steps, callback);
 
   function validateOptions(async_callback) {
-    if (account && !validator.isValid(account, 'RippleAddress')) {
+    if (account && !ripple.UInt160.is_valid(account)) {
       return callback(new errors.InvalidRequestError('Invalid parameter: account. Must be a valid Ripple Address'));
     }
 
@@ -390,7 +390,7 @@ function getAccountTransactions(options, response, callback) {
       );
     }
 
-    if (!validator.isValid(options.account, 'RippleAddress')) {
+    if (!ripple.UInt160.is_valid(options.account)) {
       return async_callback(new errors.InvalidRequestError('Invalid parameter: account. ' +
         'Must supply a valid Ripple Address to query account transactions')
       );

--- a/schemas/RippleAddress.json
+++ b/schemas/RippleAddress.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "RippleAddress",
-  "description": "A Ripple account address",
-  "type": "string",
-  "pattern": "^r[1-9A-HJ-NP-Za-km-z]{25,33}$"
-}


### PR DESCRIPTION
From the (wiki)[https://wiki.ripple.com/Accounts]

> In ripple-lib, use `UInt160.is_valid(x)`

```
> var validator = require('./lib/schema-validator.js');
> validator.isValid('rMwjYedjc7qqtKYVLiAccJSmCwih4LnE21', 'RippleAddress')
true

> var UInt160 = require('ripple-lib').UInt160
> UInt160.is_valid('rMwjYedjc7qqtKYVLiAccJSmCwih4LnE21')
false
```