### PR TITLE
[TASK] Payment History: Make response objects consistent (RLJS-160)

### DIFF
--- a/lib/tx-to-rest-converter.js
+++ b/lib/tx-to-rest-converter.js
@@ -78,7 +78,6 @@ TxToRestConverter.prototype.parsePaymentFromTx = function(tx, options, callback)
     renameCounterpartyToIssuer(parseBalanceChanges(tx.meta)) : [];
 
   var payment = {
-    hash: tx.hash,
     // User supplied
     source_account: tx.Account,
     source_tag: (tx.SourceTag ? '' + tx.SourceTag : ''),

--- a/test/fixtures/payments.js
+++ b/test/fixtures/payments.js
@@ -16,6 +16,206 @@ module.exports.requestPath = function(address, params) {
   return '/v1/accounts/' + address + '/payments' + ( params || '' );
 };
 
+module.exports.accountTransactionsResponse = function(request, options) {
+  options = options || {};
+  _.defaults(options, {
+    memos: [],
+    hash: module.exports.VALID_TRANSACTION_HASH
+  });
+
+  return JSON.stringify({
+    "id": request.id,
+    "status": 'success',
+    "type": 'response',
+    "result": {
+      "transactions": [{
+        "tx": {
+          "Account": fromAccount,
+          "Amount": {
+            "currency": 'USD',
+            "issuer": 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH',
+            "value": '0.001'
+          },
+          "Destination": 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH',
+          "Fee": '10',
+          "Flags": 0,
+          "Memos": options.memos,
+          "Paths": [
+            [
+              {
+                "currency": 'USD',
+                "issuer": 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                "type": 48,
+                "type_hex": '0000000000000030'
+              },
+              {
+                "account": 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                "currency": 'USD',
+                "issuer": 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                "type": 49,
+                "type_hex": '0000000000000031'
+              }
+            ] 
+          ],
+          "SendMax": '1112209',
+          "Sequence": 4,
+          "SigningPubKey": '02BC8C02199949B15C005B997E7C8594574E9B02BA2D0628902E0532989976CF9D',
+          "TransactionType": 'Payment',
+          "TxnSignature": '304502204EE3E9D1B01D8959B08450FCA9E22025AF503DEF310E34A93863A85CAB3C0BC5022100B61F5B567F77026E8DEED89EED0B7CAF0E6C96C228A2A65216F0DC2D04D52083',
+          "date": 416447810,
+          "hash": options.hash,
+          "inLedger": 348860,
+          "ledger_index": 348860
+        },
+        "meta": {
+          "AffectedNodes": [
+            {
+            "ModifiedNode": {
+              "FinalFields": {
+                "Account": 'r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr',
+                "BookDirectory": '4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5E03E788E09BB000',
+                "BookNode": '0000000000000000',
+                "Flags": 0,
+                "OwnerNode": '0000000000000000',
+                "Sequence": 58,
+                "TakerGets": {
+                  "currency": 'USD',
+                  "issuer": 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                  "value": '5.648998'
+                },
+                "TakerPays": '6208248802'
+              },
+              "LedgerEntryType": 'Offer',
+              "LedgerIndex": '3CFB3C79D4F1BDB1EE5245259372576D926D9A875713422F7169A6CC60AFA68B',
+              "PreviousFields": {
+                "TakerGets": {
+                  "currency": 'USD',
+                  "issuer": 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                  "value": '5.65'
+                },
+                "TakerPays": '6209350000'
+              },
+              "PreviousTxnID": '8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4',
+              "PreviousTxnLgrSeq": 348433
+            }
+          },
+          {
+            "ModifiedNode": {
+              "FinalFields": {
+                "Balance": {
+                  "currency": 'USD',
+                  "issuer": 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                  "value": '-0.001'
+                },
+                "Flags": 131072,
+                "HighLimit": {
+                  "currency": 'USD',
+                  "issuer": 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH',
+                  "value": '1'
+                },
+                "HighNode": '0000000000000000',
+                "LowLimit": {
+                  "currency": 'USD',
+                  "issuer": 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                  "value": '0'
+                },
+                "LowNode": '0000000000000002'
+              },
+              "LedgerEntryType": 'RippleState',
+              "LedgerIndex": '4BD1874F8F3A60EDB0C23F5BD43E07953C2B8741B226648310D113DE2B486F01',
+              "PreviousFields": {
+                "Balance": {
+                  "currency": 'USD',
+                  "issuer": 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                  "value": '0'
+                }
+              },
+              "PreviousTxnID": '5B2006DAD0B3130F57ACF7CC5CCAC2EEBCD4B57AAA091A6FD0A24B073D08ABB8',
+              "PreviousTxnLgrSeq": 343703
+            }
+          },
+          {
+            "ModifiedNode": {
+              "FinalFields": {
+                "Account": 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
+                "Balance": '9998898762',
+                "Flags": 0,
+                "OwnerCount": 3,
+                "Sequence": 5
+              },
+              "LedgerEntryType": 'AccountRoot',
+              "LedgerIndex": '4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05',
+              "PreviousFields": {
+                "Balance": '9999999970',
+                "Sequence": 4
+              },
+              "PreviousTxnID": '53354D84BAE8FDFC3F4DA879D984D24B929E7FEB9100D2AD9EFCD2E126BCCDC8',
+              "PreviousTxnLgrSeq": 343570
+            }
+          },
+          {
+            "ModifiedNode": {
+              "FinalFields": {
+                "Account": 'r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr',
+                "Balance": '912695302618',
+                "Flags": 0,
+                "OwnerCount": 10,
+                "Sequence": 59
+              },
+              "LedgerEntryType": 'AccountRoot',
+              "LedgerIndex": 'F3E119AAA87AF3607CF87F5523BB8278A83BCB4142833288305D767DD30C392A',
+              "PreviousFields": {
+                "Balance": '912694201420'
+              },
+              "PreviousTxnID": '8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4',
+              "PreviousTxnLgrSeq": 348433
+            }
+          },
+          {
+            "ModifiedNode": {
+              "FinalFields": {
+                "Balance": {
+                  "currency": 'USD',
+                  "issuer": 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                  "value": '-5.5541638883365'
+                },
+                "Flags": 131072,
+                "HighLimit": {
+                  "currency": 'USD',
+                  "issuer": 'r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr',
+                  "value": '1000'
+                },
+                "HighNode": '0000000000000000',
+                "LowLimit": {
+                  "currency": 'USD',
+                  "issuer": 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                  "value": '0'
+                },
+                "LowNode": '000000000000000C'
+              },
+              "LedgerEntryType": 'RippleState',
+              "LedgerIndex": 'FA1255C2E0407F1945BCF9351257C7C5C28B0F5F09BB81C08D35A03E9F0136BC',
+              "PreviousFields": {
+                "Balance": {
+                  "currency": 'USD',
+                  "issuer": 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                  "value": '-5.5551658883365'
+                }
+              },
+              "PreviousTxnID": '8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4',
+              "PreviousTxnLgrSeq": 348433
+            }
+          }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": 'tesSUCCESS'
+        },
+        "validated": true
+      }]
+    }
+  });
+};
+
 module.exports.transactionResponse = function(request, options) {
   options = options || {};
   _.defaults(options, {
@@ -244,19 +444,20 @@ module.exports.ledgerResponse = function(request) {
 
 module.exports.RESTTransactionResponse = function(options) {
   options = options || {};
+
   _.defaults(options, {
     memos: undefined,
     hash: module.exports.VALID_TRANSACTION_HASH,
     fromAccount: fromAccount,
     toAccount: issuerAccount,
     fee: '0.00001',
-    ledger: '348860'
+    ledger: '348860',
+    client_resource_id: ''
   });
 
   return JSON.stringify({
     "success": true,
     "payment": {
-      "hash": options.hash,
       "source_account": options.fromAccount,
       "source_tag": '',
       "source_amount": {
@@ -296,9 +497,75 @@ module.exports.RESTTransactionResponse = function(options) {
       ],
       "memos": options.memos
     },
+    "client_resource_id": options.client_resource_id,
     "hash": options.hash,
-    "ledger": String(options.ledger),
+    "ledger": options.ledger,
     "state": 'validated'
+  });
+};
+
+module.exports.RESTAccountTransactionsResponse = function(options) {
+  options = options || {};
+  _.defaults(options, {
+    memos: undefined,
+    hash: module.exports.VALID_TRANSACTION_HASH,
+    fromAccount: fromAccount,
+    toAccount: issuerAccount,
+    fee: '0.00001',
+    ledger: '348860',
+    client_resource_id: ''
+  });
+
+  return JSON.stringify({
+    "success": true,
+    "payments": [
+      {
+        "payment": {
+          "source_account": options.fromAccount,
+          "source_tag": '',
+          "source_amount": {
+            "value": '1.112209',
+            "currency": 'XRP',
+            "issuer": ''
+          },
+          "source_slippage": '0',
+          "destination_account": options.toAccount,
+          "destination_tag": '',
+          "destination_amount": {
+            "currency": 'USD',
+            "issuer": options.toAccount,
+            "value": '0.001'
+          },
+          "invoice_id": '',
+          "paths": '[[{"currency":"USD","issuer":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","type":48,"type_hex":"0000000000000030"},{"account":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","currency":"USD","issuer":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","type":49,"type_hex":"0000000000000031"}]]',
+          "no_direct_ripple": false,
+          "partial_payment": false,
+          "direction": 'outgoing',
+          "result": 'tesSUCCESS',
+          "timestamp": '2013-03-12T23:56:50.000Z',
+          "fee": options.fee,
+          "source_balance_changes": [
+            {
+              "value": '-1.101208',
+              "currency": 'XRP',
+              "issuer": ''
+            }
+          ],
+          "destination_balance_changes": [
+            {
+              "value": '0.001',
+              "currency": 'USD',
+              "issuer": 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
+            }
+          ],
+          "memos": options.memos
+        },
+        "client_resource_id": options.client_resource_id,
+        "hash": options.hash,
+        "ledger": options.ledger,
+        "state": 'validated'
+      }
+    ]
   });
 };
 
@@ -307,13 +574,13 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
   _.defaults(options, {
     memos: undefined,
     hash: module.exports.VALID_TRANSACTION_HASH,
-    ledger: '10151421'
+    ledger: '10151421',
+    client_resource_id: ''
   });
 
   return JSON.stringify({
     "success": true,
     "payment": {
-      "hash": options.hash,
       "source_account": "r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE",
       "source_tag": "",
       "source_amount": {
@@ -357,8 +624,9 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
         }
       ]
     },
+    "client_resource_id": options.client_resource_id,
     "hash": options.hash,
-    "ledger": String(options.ledger),
+    "ledger": options.ledger,
     "state": "validated",
   });
 };
@@ -778,7 +1046,8 @@ module.exports.transactionVerifiedResponse = function(options) {
   options = options || {};
   _.defaults(options, {
     fee: '10',
-    hash: module.exports.VALID_SUBMITTED_TRANSACTION_HASH
+    hash: module.exports.VALID_SUBMITTED_TRANSACTION_HASH,
+    ledger: '34886'
   });
 
   return JSON.stringify(
@@ -787,7 +1056,7 @@ module.exports.transactionVerifiedResponse = function(options) {
       "engine_result_code": 0,
       "engine_result_message": "The transaction was applied.",
       "ledger_hash": "F7D1AFD4B7F9F895A4720ADC612A7D6D87FAE94BAD86EB55C2951C7D311D6F94",
-      "ledger_index": 348860,
+      "ledger_index": options.ledger,
       "status": "closed",
       "meta": {
         "AffectedNodes": [
@@ -980,7 +1249,8 @@ module.exports.verifiedResponseComplexCurrency = function(options) {
   _.defaults(options, {
     hash: module.exports.VALID_SUBMITTED_TRANSACTION_HASH,
     fromAccount: fromAccount,
-    toAccount: toAccount
+    toAccount: toAccount,
+    ledger: '10151421'
   });
 
   return JSON.stringify({
@@ -988,7 +1258,7 @@ module.exports.verifiedResponseComplexCurrency = function(options) {
     "engine_result_code": 0,
     "engine_result_message": "The transaction was applied.",
     "ledger_hash": "4D63F66E96FA9FDD477A3CECE7BCCC474CF69820530F0993853BD74810939B2B",
-    "ledger_index": 10151421,
+    "ledger_index": options.ledger,
     "meta": {
       "AffectedNodes": [
         {

--- a/test/unit/fixtures/tx-converter.js
+++ b/test/unit/fixtures/tx-converter.js
@@ -378,7 +378,6 @@ module.exports.paymentTx = function(options) {
 };
 
 module.exports.paymentRest = {
-  hash: VALID_TRANSACTION_HASH,
   source_account: addresses.VALID,
   source_tag: '',
   source_amount: { value: '1.112209', currency: 'XRP', issuer: '' },


### PR DESCRIPTION
- Adds similar metadata to the `payment` object when requesting more
  than one payment (`GET /v1/accounts/:address/payments`)