### PR TITLE
[TASK] Payments: Use `counterparty` in place of `issuer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Ripple-REST API #
-
 [![Build Status](https://travis-ci.org/ripple/ripple-rest.svg?branch=develop)](https://travis-ci.org/ripple/ripple-rest)
 [![Coverage Status](https://coveralls.io/repos/ripple/ripple-rest/badge.png?branch=develop)](https://coveralls.io/r/ripple/ripple-rest?branch=develop)
 [![Code Climate](https://codeclimate.com/github/ripple/ripple-rest.png)](https://codeclimate.com/github/ripple/ripple-rest)
 
 [![NPM](https://nodei.co/npm/ripple-rest.png)](https://www.npmjs.org/package/ripple-rest)
 
+# Ripple-REST API #
+
 The Ripple-REST API provides a simplified, easy-to-use interface to the Ripple Network via a RESTful API. This page explains how to use the API to send and receive payments on Ripple.
 
-We recommend Ripple-REST for users just getting started with Ripple, since it provides high-level abstractions and convenient simplifications in the data format. If you prefer to access a `rippled` server directly, you can use [rippled's WebSocket or JSON-RPC APIs](rippled-apis.html) instead, which provide the full power of Ripple at the cost of more complexity.
+We recommend Ripple-REST for users just getting started with Ripple, since it provides high-level abstractions and convenient simplifications in the data format. If you prefer to access a `rippled` server directly, you can use [rippled's WebSocket or JSON-RPC APIs](https://ripple.com/build/rippled-apis) instead, which provide the full power of Ripple at the cost of more complexity.
 
 
 ## Available API Routes ##
@@ -33,7 +33,7 @@ We recommend Ripple-REST for users just getting started with Ripple, since it pr
 * [Cancel Order - `DELETE /v1/accounts/{:address}/orders/{:sequence}`](#cancel-order)
 * [Get Account Orders - `GET /v1/accounts/{:address}/orders`](#get-account-orders)
 * [Get Order Book - `GET /v1/accounts/{:address}/order_book/{:base}/{:counter}`](#get-order-book)
-* [Get Order Transaction - `GET /v1/accounts{:address}/orders/{:hash}`](#get-order)
+* [Get Order Transaction - `GET /v1/accounts{:address}/orders/{:hash}`](#get-order-transaction)
 
 #### Trustlines ####
 
@@ -87,9 +87,9 @@ When you submit a payment for processing, you assign a unique `client resource i
 
 The Ripple protocol supports multiple types of transactions, not just payments. Transactions are considered to be any changes to the database made on behalf of a Ripple Address. Transactions are first constructed and then submitted to the network. After transaction processing, meta data is associated with the transaction which itemizes the resulting changes to the ledger.
 
- * Payment: A Payment transaction is an authorized transfer of balance from one address to another. (This maps to rippled's [Payment transaction type](transactions.html#payment))
- * Trustline: A Trustline transaction is an authorized grant of trust between two addresses. (This maps to rippled's [TrustSet transaction type](transactions.html#trustset))
- * Setting: A Setting transaction is an authorized update of account flags under a Ripple Account. (This maps to rippled's [AccountSet transaction type](transactions.html#accountset))
+ * Payment: A Payment transaction is an authorized transfer of balance from one address to another. (This maps to rippled's [Payment transaction type](https://ripple.com/build/transactions#payment))
+ * Trustline: A Trustline transaction is an authorized grant of trust between two addresses. (This maps to rippled's [TrustSet transaction type](https://ripple.com/build/transactions#trustset))
+ * Setting: A Setting transaction is an authorized update of account flags under a Ripple Account. (This maps to rippled's [AccountSet transaction type](https://ripple.com/build/transactions#accountset))
  
 ### Client Resource IDs ###
 
@@ -127,9 +127,9 @@ As a programmer, you will also need to have a suitable HTTP client that allows y
  * The [Poster Firefox extension](https://addons.mozilla.org/en-US/firefox/addon/poster/)
  * The [Postman Chrome extension](https://chrome.google.com/webstore/detail/postman-rest-client/fdmmgilgnpjigdojojpjoooidkmcomcm?hl=en)
 
-You can also use the [REST API Tool](https://ripple.com/build/rest-tool/) here on the Dev Portal to try out the API.
+You can also use the [REST API Tool](https://ripple.com/build/rest-tool) here on the Dev Portal to try out the API.
 
-[Try it! >](https://ripple.com/build/rest-tool/)
+[Try it! >](https://ripple.com/build/rest-tool)
 
 ### Exploring the API ###
 
@@ -312,7 +312,7 @@ Example error:
     "success": false,
     "error_type": "invalid_request",
     "error": "Invalid parameter: destination_amount",
-    "message": "Non-XRP payment must have an issuer"
+    "message": "Non-XRP payment must have a counterparty"
 }
 ```
 
@@ -327,7 +327,7 @@ You should parse these numbers into a numeric data type with adequate precision.
 
 There are two kinds of currency on the Ripple network: XRP, and issuances. XRP is the native cryptocurrency that only exists in the network, and can be held by accounts and sent directly to other accounts with no trust necessary.
 
-All other currencies take the form of *issuances*, which are held in the *trust lines* that link accounts. Issuances are identified by a `counterparty` on the other end of the trust line, sometimes also called the `issuer`. Sending and trading issuances actually means debiting the balance of a trust line and crediting the balance of another trust line linked to the same account. Ripple ensures this operation happens atomically.
+All other currencies take the form of *issuances*, which are held in the *trust lines* that link accounts. Issuances are identified by a `counterparty` on the other end of the trust line. Sending and trading issuances actually means debiting the balance of a trust line and crediting the balance of another trust line linked to the same account. Ripple ensures this operation happens atomically.
 
 Issuances are typically created by Gateway accounts in exchange for assets in the outside world. In most cases, the `counterparty` of a currency refers to the gateway that created the issuances. XRP never has a counterparty.
 
@@ -343,7 +343,7 @@ When an amount of currency is specified as part of a JSON body, it is encoded as
 | value | String (Quoted decimal) | The quantity of the currency |
 | currency | String | Three-digit [ISO 4217 Currency Code](http://www.xe.com/iso4217.php) specifying which currency. Alternatively, a 160-bit hex value. (Some advanced features, like [demurrage](https://ripple.com/wiki/Gateway_demurrage), require the hex version.) |
 | counterparty | String | (New in [v1.3.2](https://github.com/ripple/ripple-rest/releases/tag/1.3.2-rc4)) The Ripple address of the account that is a counterparty to this currency. This is usually an [issuing gateway](https://wiki.ripple.com/Gateway_List). Always omitted, or an empty string, for XRP. |
-| issuer | String | (Prior to 1.3.2) **DEPRECATED** alias for `counterparty`. Some methods may still return this instead. |
+| issuer | String | (Prior to 1.4.0) **DEPRECATED** alias for `counterparty`. |
 
 
 Example Amount Object:
@@ -407,7 +407,7 @@ An example Payment object looks like this:
     "source_amount": {
         "value": "0.001",
         "currency": "XRP",
-        "issuer": ""
+        "counterparty": ""
     },
     "source_slippage": "0",
     "destination_address": "rNw4ozCG514KEjPs5cDrqEcdsi31Jtfm5r",
@@ -415,7 +415,7 @@ An example Payment object looks like this:
     "destination_amount": {
         "value": "0.001",
         "currency": "XRP",
-        "issuer": ""
+        "counterparty": ""
     },
     "invoice_id": "",
     "paths": "[]",
@@ -438,7 +438,7 @@ The fields of a Payment object are defined as follows:
 | `invoice_id` | String | (Optional) Arbitrary 256-bit hash that can be used to link payments to an invoice or bill. |
 | `paths` | String | A "stringified" version of the Ripple PathSet structure. You can get a path for your payment from the [Prepare Payment](#prepare-payment) method. |
 | `no_direct_ripple` | Boolean  | (Optional, defaults to false) `true` if `paths` are specified and the sender would like the Ripple Network to disregard any direct paths from the `source_address` to the `destination_address`. This may be used to take advantage of an arbitrage opportunity or by gateways wishing to issue balances from a hot wallet to a user who has mistakenly set a trustline directly to the hot wallet. Most users will not need to use this option. |
-| `partial_payment` | Boolean | (Optional, defaults to false) If set to `true`, fees will be deducted from the delivered amount instead of the sent amount. (*Caution:* There is no minimum amount that will actually arrive as a result of using this flag; only a miniscule amount may actually be received.) See [Partial Payments](transactions.html#partial-payments) |
+| `partial_payment` | Boolean | (Optional, defaults to false) If set to `true`, fees will be deducted from the delivered amount instead of the sent amount. (*Caution:* There is no minimum amount that will actually arrive as a result of using this flag; only a miniscule amount may actually be received.) See [Partial Payments](https://ripple.com/build/transactions#partial-payments) |
 | `memos` | Array | (Optional) Array of [memo objects](#memo-objects), where each object is an arbitrary note to send with this payment. |
 
 Submitted transactions can have additional fields reflecting the current status and outcome of the transaction, including:
@@ -460,7 +460,7 @@ Submitted transactions can have additional fields reflecting the current status 
 
 ### Memo Objects ###
 
-(New in [Ripple-REST v1.3.0](https://github.com/ripple/ripple-rest/releases/tag/1.3.0))
+_(New in [Ripple-REST v1.3.0](https://github.com/ripple/ripple-rest/releases/tag/1.3.0))_
 
 Memo objects represent arbitrary data that can be included in a transaction. The overall size of the `memos` field cannot exceed 1KB after serialization.
 
@@ -489,18 +489,20 @@ Example of the memos field:
 
 ## Order Objects ##
 
+_(New in [Ripple-REST 1.4.0](https://github.com/ripple/ripple-rest/releases/tag/1.4.0-rc1))_
+
 An order object describes an offer to exchange two currencies. Order objects are used when creating or looking up individual orders.
 
 | Field | Value | Description |
 |-------|-------|-------------|
-| type  | String (`buy` or `sell`) | Whether the order is to buy or sell. | 
+| type  | String (`buy` or `sell`) | Whether the order is to buy or sell. |
 | taker\_pays | String ([Amount Object](#amount_object)) | The amount the taker must pay to consume this order. |
 | taker\_gets | String ([Amount Object](#amount_object)) | The amount the taker will get once the order is consumed. |
 | sequence   | Number | The sequence number of the transaction that created the order. Used in combination with account to uniquely identify the order. |
-| passive    | Boolean | Whether the order should be [passive](transactions.html#offercreate-flags). |
-| sell       | Boolean | Whether the order should be [sell](transactions.html#offercreate-flags). |
-| immediate\_or\_cancel | Boolean | Whether the order should be [immediate or cancel](transactions.html#offercreate-flags). |
-| fill\_or\_kill        | Boolean | Whether the order should be [fill or kill](transactions.html#offercreate-flags). |
+| passive    | Boolean | Whether the order should be [passive](https://ripple.com/build/transactions#offercreate-flags). |
+| sell       | Boolean | Whether the order should be [sell](https://ripple.com/build/transactions#offercreate-flags). |
+| immediate\_or\_cancel | Boolean | Whether the order should be [immediate or cancel](https://ripple.com/build/transactions#offercreate-flags). |
+| fill\_or\_kill        | Boolean | Whether the order should be [fill or kill](https://ripple.com/build/transactions#offercreate-flags). |
 
 ## Order Change Objects ##
 
@@ -517,16 +519,16 @@ An order change object describes the changes to to a Ripple account's open order
 
 ## Bid Objects ##
 
-An bid object describes an offer to exchange two currencies, including the current funding status of the offer. Bid objects are used when retrieving an order book.
+An bid object describes an offer to exchange two currencies, including the current funding status of the offer. Bid objects are used to describe bids and asks when retrieving an order book. 
 
 | Field | Value | Description |
 |-------|-------|-------------|
 | type  | String (`buy` or `sell`) | Whether the order is to buy or sell. |
 | price | String ([Amount Object](#amount_object)) | The quoted price, denominated in total units of the counter currency per unit of the base currency |
 | taker\_pays\_total | String ([Amount Object](#amount_object)) | The total amount the taker must pay to consume this order. |
-| taker\_pays\_funded | String ([Amount Object](#amount_object)) | The actual amount the taker must pay to consume this order, if the order is (partially funded)[https://wiki.ripple.com/Unfunded_offers]. |
+| taker\_pays\_funded | String ([Amount Object](#amount_object)) | The actual amount the taker must pay to consume this order, if the order is [partially funded](https://wiki.ripple.com/Unfunded_offers). |
 | taker\_gets\_total | String ([Amount Object](#amount_object)) | The total amount the taker will get once the order is consumed. |
-| taker\_gets\_funded | String ([Amount Object](#amount_object)) | The actual amount the taker will get once the order is consumed, if the order is (partially funded)[https://wiki.ripple.com/Unfunded_offers]. |
+| taker\_gets\_funded | String ([Amount Object](#amount_object)) | The actual amount the taker will get once the order is consumed, if the order is [partially funded](https://wiki.ripple.com/Unfunded_offers). |
 | order\_maker | String | The Ripple address of the account that placed the bid or ask on the order book. |
 | sequence | Number | The sequence number of the transaction that created the order. Used in combination with account to uniquely identify the order. |
 | sell     | Boolean | Whether the order should be [sell](https://ripple.com/build/transactions/#offercreate-flags). |
@@ -549,8 +551,8 @@ From the perspective of an account on one side of the trustline, the trustline h
 | reciprocated_limit | String (Quoted decimal) | (Read-only) The maximum amount of currency issued by this account that the counterparty account should hold. |
 | account\_allows\_rippling | Boolean | If set to false on two trustlines from the same account, payments cannot ripple between them. (See the [NoRipple flag](https://ripple.com/knowledge_center/understanding-the-noripple-flag/) for details.) |
 | counterparty\_allows\_rippling | Boolean | (Read-only) If false, the counterparty account has the [NoRipple flag](https://ripple.com/knowledge_center/understanding-the-noripple-flag/) enabled. |
-| account\_trustline\_frozen | Boolean | Indicates whether this account has [frozen](https://wiki.ripple.com/Freeze) the trustline. (`account_froze_trustline` prior to [v1.3.2](https://github.com/ripple/ripple-rest/releases/tag/1.3.2-rc4)) |
-| counterparty\_trustline\_frozen | Boolean | (Read-only) Indicates whether the counterparty account has [frozen](https://wiki.ripple.com/Freeze) the trustline. (`counterparty_froze_line` prior to [v1.3.2](https://github.com/ripple/ripple-rest/releases/tag/1.3.2-rc4)) |
+| account\_trustline\_frozen | Boolean | Indicates whether this account has [frozen](https://wiki.ripple.com/Freeze) the trustline. (`account_froze_trustline` prior to [v1.4.0](https://github.com/ripple/ripple-rest/releases/tag/1.4.0-rc1)) |
+| counterparty\_trustline\_frozen | Boolean | (Read-only) Indicates whether the counterparty account has [frozen](https://wiki.ripple.com/Freeze) the trustline. (`counterparty_froze_line` prior to [v1.4.0](https://github.com/ripple/ripple-rest/releases/tag/1.4.0-rc1)) |
 
 The read-only fields indicate portions of the trustline that pertain to the counterparty, and can only be changed by that account. (The `counterparty` field is technically part of the identity of the trustline. If you "change" it, that just means that you are referring to a different trustline object.)
 
@@ -569,12 +571,17 @@ Accounts are the core unit of authentication in the Ripple Network. Each account
 
 Randomly generate keys for a potential new Ripple account.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/wallet/new
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#generate-wallet)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#generate-wallet)
 
 There are two steps to making a new account on the Ripple network: randomly creating the keys for that account, and sending it enough XRP to meet the account reserve.
 
@@ -605,12 +612,17 @@ The second step is [making a payment](#payments) of XRP to the new account addre
 
 Retrieve the current balances for the given Ripple account.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/balances
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#get-account-balances)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#get-account-balances)
 
 The following URL parameters are required by this API endpoint:
 
@@ -668,12 +680,17 @@ There is one entry in the `balances` array for the account's XRP balance, and ad
 
 Retrieve the current settings for a given account.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/settings
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#get-account-settings)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#get-account-settings)
 
 The following URL parameters are required by this API endpoint:
 
@@ -710,8 +727,8 @@ The response contains a `settings` object, with the following fields:
 | Field | Value | Description |
 |-------|-------|-------------|
 | account | String | The Ripple address of this account |
-| transfer_rate | String (Quoted decimal number) | If set, imposes a fee for transferring balances issued by this account. Must be between 1 and 2, with up to 9 decimal places of precision. See [TransferRate](transactions.html#transferrate) for details. |
-| password_spent | Boolean | If false, then this account can submit a special [SetRegularKey transaction](transactions.html#setregularkey) without a transaction fee. |
+| transfer_rate | String (Quoted decimal number) | If set, imposes a fee for transferring balances issued by this account. Must be between 1 and 2, with up to 9 decimal places of precision. See [TransferRate](https://ripple.com/build/transactions#transferrate) for details. |
+| password_spent | Boolean | If false, then this account can submit a special [SetRegularKey transaction](https://ripple.com/build/transactions#setregularkey) without a transaction fee. |
 | require\_destination\_tag | Boolean | If true, require a destination tag to send payments to this account. (This is intended to protect users from accidentally omitting the destination tag in a payment to a gateway's hosted wallet.) |
 | require_authorization | Boolean | If true, require authorization for users to hold balances issued by this account. (This prevents users unknown to a gateway from holding funds issued by that gateway.) |
 | disallow_xrp | Boolean | If true, XRP should not be sent to this account. (Enforced in clients but not in the server, because it could cause accounts to become unusable if all their XRP were spent.) |
@@ -730,6 +747,9 @@ The response contains a `settings` object, with the following fields:
 
 Modify the existing settings for an account.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 POST /v1/accounts/{:address}/settings?validated=true
@@ -747,7 +767,9 @@ POST /v1/accounts/{:address}/settings?validated=true
 }
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#update-account-settings)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#update-account-settings)
 
 The following URL parameters are required by this API endpoint:
 
@@ -824,12 +846,17 @@ The response is a JSON object containing the following fields:
 
 Get quotes for possible ways to make a particular payment.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:source_address}/payments/paths/{:destination_address}/{:amount}
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#prepare-payment)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#prepare-payment)
 
 The following URL parameters are required by this API endpoint:
 
@@ -845,7 +872,7 @@ Optionally, you can also include the following as a query parameter:
 |-------|------|-------------|
 | `source_currencies` | Comma-separated list of source currencies. Each should be an [ISO 4217 currency code](http://www.xe.com/iso4217.php), or a `{:currency}+{:counterparty}` string. | Filters possible payments to include only ones that spend the source account's balances in the specified currencies. If a counterparty is not specified, include all issuances of that currency held by the sending account. |
 
-Before you make a payment, it is necessary to figure out the possible ways in which that payment can be made. This method gets a list possible ways to make a payment, but it does not affect the network. This method effectively performs a [ripple_path_find](rippled-apis.html#ripple-path-find) and constructs payment objects for the paths it finds.
+Before you make a payment, it is necessary to figure out the possible ways in which that payment can be made. This method gets a list possible ways to make a payment, but it does not affect the network. This method effectively performs a [ripple_path_find](https://ripple.com/build/rippled-apis#ripple-path-find) and constructs payment objects for the paths it finds.
 
 You can then choose one of the returned payment objects, modify it as desired (for example, to set slippage values or tags), and then submit the payment for processing.
 
@@ -861,7 +888,7 @@ You can then choose one of the returned payment objects, modify it as desired (f
       "source_amount": {
         "value": "1.008413509923106",
         "currency": "USD",
-        "issuer": ""
+        "counterparty": ""
       },
       "source_slippage": "0",
       "destination_account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
@@ -869,7 +896,7 @@ You can then choose one of the returned payment objects, modify it as desired (f
       "destination_amount": {
         "value": "1",
         "currency": "USD",
-        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+        "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
       },
       "invoice_id": "",
       "paths": "[[{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -882,7 +909,7 @@ You can then choose one of the returned payment objects, modify it as desired (f
       "source_amount": {
         "value": "61.06103",
         "currency": "XRP",
-        "issuer": ""
+        "counterparty": ""
       },
       "source_slippage": "0",
       "destination_account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
@@ -890,7 +917,7 @@ You can then choose one of the returned payment objects, modify it as desired (f
       "destination_amount": {
         "value": "1",
         "currency": "USD",
-        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+        "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
       },
       "invoice_id": "",
       "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rpDMez6pm6dBve2TJsmDpv7Yae6V5Pyvy2\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpDMez6pm6dBve2TJsmDpv7Yae6V5Pyvy2\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rHAwwozJw6FHfnJfRQaFXrkGHocGoaNYSy\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rEtr3Kzh5MmhPbeNu6PDtQZsKBpgFEEEo5\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rKvPTQrD8ap1Y8TSmKjcK6G7q7Kvx7RAqQ\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -912,8 +939,11 @@ __NOTE:__ This command may be quite slow. If the command times out, please try i
 
 Submit a payment object to be processed and executed.
 
+<!-- <div class='multicode'> -->
 
-```js
+<!-- *REST* -->
+
+```
 POST /v1/accounts/{address}/payments?validated=true
 
 {
@@ -928,7 +958,7 @@ POST /v1/accounts/{address}/payments?validated=true
     "source_amount": {
       "value": "5.01",
       "currency": "USD",
-      "issuer": ""
+      "counterparty": ""
     },
     "source_slippage": "0",
     "destination_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -936,7 +966,7 @@ POST /v1/accounts/{address}/payments?validated=true
     "destination_amount": {
       "value": "5",
       "currency": "USD",
-      "issuer": ""
+      "counterparty": ""
     },
     "invoice_id": "",
     "paths": "[[{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -946,8 +976,9 @@ POST /v1/accounts/{address}/payments?validated=true
 }
 ```
 
+<!-- </div> -->
 
-[Try it! >](https://ripple.com/build/rest-tool/#submit-payment)
+[Try it! >](https://ripple.com/build/rest-tool#submit-payment)
 
 The JSON body of the request includes the following parameters:
 
@@ -1006,12 +1037,17 @@ The response can take two formats, depending on the `validated` query parameter:
 
 Retrieve the details of a payment, including the current state of the transaction and the result of transaction processing.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/payments/{:id}
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#confirm-payment)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#confirm-payment)
 
 The following URL parameters are required by this API endpoint:
 
@@ -1031,7 +1067,7 @@ The following URL parameters are required by this API endpoint:
     "source_amount": {
       "value": "0.00001",
       "currency": "XRP",
-      "issuer": ""
+      "counterparty": ""
     },
     "source_slippage": "0",
     "destination_account": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
@@ -1039,7 +1075,7 @@ The following URL parameters are required by this API endpoint:
     "destination_amount": {
       "value": "0.00000005080000000000001",
       "currency": "USD",
-      "issuer": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"
+      "counterparty": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"
     },
     "invoice_id": "",
     "paths": "[]",
@@ -1052,28 +1088,28 @@ The following URL parameters are required by this API endpoint:
     "balance_changes": [{
       "currency": "XRP",
       "value": "-0.00002",
-      "issuer": ""
+      "counterparty": ""
     }],
     "source_balance_changes": [{
       "currency": "XRP",
       "value": "-0.00002",
-      "issuer": ""
+      "counterparty": ""
     }],
     "destination_balance_changes": [{
       "currency": "USD",
       "value": "5.08e-8",
-      "issuer": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"
+      "counterparty": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"
     }],
     "order_changes": [],
     "destination_amount_submitted": {
       "value": "0.01",
       "currency": "USD",
-      "issuer": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"
+      "counterparty": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"
     },
     "source_amount_submitted": {
       "value": "0.00001",
       "currency": "XRP",
-      "issuer": ""
+      "counterparty": ""
     }
   },
   "client_resource_id": "",
@@ -1091,7 +1127,7 @@ The following URL parameters are required by this API endpoint:
 
 If the `state` field has the value `"validated"`, then the payment has been finalized, and is included in the shared global ledger. However, this does not necessarily mean that it succeeded. Check the `payment.result` field for a value of `"tesSUCCESS"` to see if the payment was successfully executed. If the `payment.partial_payment` flag is *true*, then you should also consult the `payment.destination_balance_changes` array to see how much currency was actually delivered to the destination account.
 
-Processing a payment can take several seconds to complete, depending on the [consensus process](consensus-whitepaper.html). If the payment does not exist yet, or has not been validated, you should wait a few seconds before checking again.
+Processing a payment can take several seconds to complete, depending on the [consensus process](https://ripple.com/consensus-whitepaper/). If the payment does not exist yet, or has not been validated, you should wait a few seconds before checking again.
 
 
 
@@ -1100,12 +1136,17 @@ Processing a payment can take several seconds to complete, depending on the [con
 
 Retrieve a selection of payments that affected the specified account.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/payments
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#get-payment-history)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#get-payment-history)
 
 The following URL parameters are required by this API endpoint:
 
@@ -1139,7 +1180,7 @@ Optionally, you can also include the following query parameters:
       "source_amount": {
         "value": "20",
         "currency": "XRP",
-        "issuer": ""
+        "counterparty": ""
       },
       "source_slippage": "0",
       "destination_account": "raKEEVSGnKSD9Zyvxu4z6Pqpm4ABH8FS6n",
@@ -1147,7 +1188,7 @@ Optionally, you can also include the following query parameters:
       "destination_amount": {
         "value": "20",
         "currency": "XRP",
-        "issuer": ""
+        "counterparty": ""
       },
       "invoice_id": "",
       "paths": "[]",
@@ -1160,17 +1201,17 @@ Optionally, you can also include the following query parameters:
       "balance_changes": [{
         "currency": "XRP",
         "value": "-20.012",
-        "issuer": ""
+        "counterparty": ""
       }],
       "source_balance_changes": [{
         "currency": "XRP",
         "value": "-20.012",
-        "issuer": ""
+        "counterparty": ""
       }],
       "destination_balance_changes": [{
         "currency": "XRP",
         "value": "20",
-        "issuer": ""
+        "counterparty": ""
       }],
       "order_changes": []
     },
@@ -1195,30 +1236,33 @@ If the length of the `payments` array is equal to `results_per_page`, then there
 
 Places an order to exchange currencies.
 
+<!-- <div class='multicode'> -->
 
+<!-- *REST* -->
 
-```js
+```
 POST /v1/accounts/{:address}/orders?validated=true
 {
-    "secret": "sneThnzgBgxc3zXPG....",
+    "secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9",
     "order": {
-      "type": "sell",
-      "taker_pays": {
-        currency: "JPY",
-        counterparty: "rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6",
-        value: "4000"
-      },
-      "taker_gets": {
-        currency: "USD",
-        counterparty: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-        value: ".25"
-      }
+        "type": "sell",
+        "taker_pays": {
+            "currency": "JPY",
+            "counterparty": "rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6",
+            "value": "4000"
+        },
+        "taker_gets": {
+            "currency": "USD",
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": ".25"
+        }
     }
 }
 ```
 
+<!-- </div> -->
 
-[Try it! >](https://ripple.com/build/rest-tool/#place-order)
+[Try it! >](https://ripple.com/build/rest-tool#place-order)
 
 The following URL parameters are required by this API endpoint:
 
@@ -1250,7 +1294,7 @@ __DO NOT SUBMIT YOUR SECRET TO AN UNTRUSTED REST API SERVER__ -- The secret key 
     "hash": "71AE74B03DE3B9A06C559AD4D173A362D96B7D2A5AA35F56B9EF21543D627F34",
     "ledger": "9592219",
     "state": "validated",
-    "account": "sneThnzgBgxc3zXPG....",
+    "account": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9",
     "taker_pays": {
       "currency": "JPY",
       "counterparty": "rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6",
@@ -1273,17 +1317,20 @@ __DO NOT SUBMIT YOUR SECRET TO AN UNTRUSTED REST API SERVER__ -- The secret key 
 
 Deletes a previous order to exchange currencies.
 
+<!-- <div class='multicode'> -->
 
+<!-- *REST* -->
 
 ```
 DELETE /v1/accounts/{:address}/orders/{:order}?validated=true
 {
-    "secret": "sneThnzgBgxc3zXPG...."
+    "secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
 }
 ```
 
+<!-- </div> -->
 
-[Try it! >](https://ripple.com/build/rest-tool/#cancel-order)
+[Try it! >](https://ripple.com/build/rest-tool#cancel-order)
 
 The following URL parameters are required by this API endpoint:
 
@@ -1317,7 +1364,7 @@ __DO NOT SUBMIT YOUR SECRET TO AN UNTRUSTED REST API SERVER__ -- The secret key 
     "hash": "71AE74B03DE3B9A06C559AD4D173A362D96B7D2A5AA35F56B9EF21543D627F34",
     "ledger": "9592219",
     "state": "validated",
-    "account": "sneThnzgBgxc3zXPG....",
+    "account": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9",
     "fee": "0.012",
     "offer_sequence": 99,
     "sequence": 100
@@ -1330,14 +1377,17 @@ __DO NOT SUBMIT YOUR SECRET TO AN UNTRUSTED REST API SERVER__ -- The secret key 
 
 Retrieves all open currency-exchange orders associated with the Ripple address.
 
+<!-- <div class='multicode'> -->
 
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/orders
 ```
 
+<!-- </div> -->
 
-[Try it! >](https://ripple.com/build/rest-tool/#get-account-orders)
+[Try it! >](https://ripple.com/build/rest-tool#get-account-orders)
 
 The following URL parameters are required by this API endpoint:
 
@@ -1526,12 +1576,17 @@ The response is an object with a `orders` array, where each member is a [order o
 Get the details of an order transaction. An order transaction either [places an order](#place-order) or [cancels an order](#cancel-order).
 
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/orders/{:hash}
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#get-order-transaction)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#get-order-transaction)
 
 The following URL parameters are required by this API endpoint:
 
@@ -1654,12 +1709,17 @@ The `direction` of the transaction is either `incoming`, `outgoing` or `unaffect
 
 Retrieves the top of the order book for a currency pair.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/order_book/{:base}/{:counter}
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#get-order-book)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#get-order-book)
 
 The following URL parameters are required by this API endpoint:
 
@@ -1822,12 +1882,17 @@ The response includes `bids` and `asks` arrays that contain [bid objects](#bid-o
 
 Retrieves all trustlines associated with the Ripple address.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/trustlines
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#get-trustlines)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#get-trustlines)
 
 The following URL parameters are required by this API endpoint:
 
@@ -1888,11 +1953,14 @@ The response is an object with a `lines` array, where each member is a [trustlin
 
 Creates or modifies a trustline.
 
+<!-- <div class='multicode'> -->
 
-```js
+<!-- *REST* -->
+
+```
 POST /v1/accounts/{:address}/trustlines?validated=true
 {
-    "secret": "sneThnzgBgxc3zXPG....",
+    "secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9",
     "trustline": {
         "limit": "110",
         "currency": "USD",
@@ -1902,7 +1970,9 @@ POST /v1/accounts/{:address}/trustlines?validated=true
 }
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#grant-trustline)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#grant-trustline)
 
 The following parameters are required in the JSON body of the request:
 
@@ -1957,12 +2027,17 @@ Notifications are sorted in order of when they occurred, so you can save the mos
 
 Get a notification for the specific transaction hash, along with links to previous and next notifications, if available.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/accounts/{:address}/notifications/{:id}
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#check-notifications)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#check-notifications)
 
 The following URL parameters are required by this API endpoint:
 
@@ -2020,12 +2095,17 @@ The following two endpoints can be used to check if the `ripple-rest` API is cur
 
 Perform a simple ping to make sure that the server is working properly.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/server/connected
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#check-connection)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#check-connection)
 
 #### Response ####
 
@@ -2043,12 +2123,17 @@ If the server has any problems, for example with connecting to the `rippled` ser
 
 Retrieve information about the current status of the Ripple-REST API and the `rippled` server it is connected to.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/server
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#get-server-status)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#get-server-status)
 
 #### Response ####
 
@@ -2118,6 +2203,8 @@ The `rippled_server_status` object may have any of the following fields:
 <!--Note: keep the above table up-to-date with the server_info command in the rippled documentation -->
 
 
+
+
 # UTILITIES #
 
 ## Retrieve Ripple Transaction ##
@@ -2125,12 +2212,17 @@ The `rippled_server_status` object may have any of the following fields:
 
 Returns a Ripple transaction, in its complete, original format.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/transactions/{:id}
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#retrieve-ripple-transaction)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#retrieve-ripple-transaction)
 
 The following URL parameters are required by this API endpoint:
 
@@ -2140,7 +2232,7 @@ The following URL parameters are required by this API endpoint:
 
 #### Response ####
 
-The result is a JSON object, whose `transaction` field has the requested transaction. See the [Transaction format documentation](transactions.html) for a complete explanation of the fields of a transaction.
+The result is a JSON object, whose `transaction` field has the requested transaction. See the [Transaction format documentation](https://ripple.com/build/transactions) for a complete explanation of the fields of a transaction.
 
 ```js
 {
@@ -2327,12 +2419,17 @@ The result is a JSON object, whose `transaction` field has the requested transac
 
 Retrieve the current transaction fee, in XRP, for the `rippled` server Ripple-REST is connected to. If Ripple-REST is connected to multiple rippled servers, returns the median fee among the connected servers.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/transaction-fee
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#retrieve-transaction-fee)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#retrieve-transaction-fee)
 
 #### Response ####
 
@@ -2350,12 +2447,17 @@ The response is a JSON object, whose `fee` field is a string containing a decima
 
 Generate a universally-unique identifier suitable for use as the Client Resource ID for a payment.
 
+<!-- <div class='multicode'> -->
+
+<!-- *REST* -->
 
 ```
 GET /v1/uuid
 ```
 
-[Try it! >](https://ripple.com/build/rest-tool/#generate-uuid)
+<!-- </div> -->
+
+[Try it! >](https://ripple.com/build/rest-tool#generate-uuid)
 
 #### Response ####
 
@@ -2365,3 +2467,4 @@ GET /v1/uuid
   "uuid": "a5a8fe40-3795-4b10-b2b6-f05f3ca31db9"
 }
 ```
+

--- a/api/lib/utils.js
+++ b/api/lib/utils.js
@@ -12,7 +12,8 @@ module.exports = {
   getUrlBase: getUrlBase,
   parseLedger: parseLedger,
   parseCurrencyAmount: parseCurrencyAmount,
-  parseCurrencyQuery: parseCurrencyQuery
+  parseCurrencyQuery: parseCurrencyQuery,
+  txFromRestAmount: txFromRestAmount
 };
 
 function dropsToXrp(drops) {
@@ -59,18 +60,30 @@ function parseLedger(ledger) {
   return 'validated';
 }
 
-function parseCurrencyAmount(currencyAmount) {
-  if (typeof currencyAmount === 'string') {
+function parseCurrencyAmount(rippledAmount) {
+  if (typeof rippledAmount === 'string') {
     return {
       currency: 'XRP',
       counterparty: '',
-      value: dropsToXrp(currencyAmount)
+      value: dropsToXrp(rippledAmount)
     };
   } else {
     return {
-      currency: currencyAmount.currency,
-      counterparty: currencyAmount.issuer,
-      value: currencyAmount.value
+      currency: rippledAmount.currency,
+      counterparty: rippledAmount.issuer,
+      value: rippledAmount.value
+    };
+  }
+}
+
+function txFromRestAmount(restAmount) {
+  if (restAmount.currency === 'XRP') {
+    return xrpToDrops(restAmount.value);
+  } else {
+    return {
+      currency: restAmount.currency,
+      issuer: restAmount.counterparty,
+      value: restAmount.value
     };
   }
 }
@@ -80,14 +93,14 @@ function parseCurrencyQuery(query) {
 
   if (!isNaN(params[0])) {
     return {
-      value:    (params.length >= 1 ? params[0] : ''),
-      currency: (params.length >= 2 ? params[1] : ''),
-      issuer:   (params.length >= 3 ? params[2] : '')
+      value:        (params.length >= 1 ? params[0] : ''),
+      currency:     (params.length >= 2 ? params[1] : ''),
+      counterparty: (params.length >= 3 ? params[2] : '')
     };
   } else {
     return {
-      currency: (params.length >= 1 ? params[0] : ''),
-      issuer:   (params.length >= 2 ? params[1] : '')
+      currency:     (params.length >= 1 ? params[0] : ''),
+      counterparty: (params.length >= 2 ? params[1] : '')
     };
   }
 }

--- a/api/orders.js
+++ b/api/orders.js
@@ -340,7 +340,7 @@ function getOrderBook(request, response, next) {
         reject(new InvalidRequestError('Invalid parameter: base. Must be a currency string in the form currency+counterparty'));
       }
 
-      if (options.base.currency !== 'XRP' && (!options.base.issuer || !ripple.UInt160.is_valid(options.base.issuer))) {
+      if (options.base.currency !== 'XRP' && (!options.base.counterparty || !ripple.UInt160.is_valid(options.base.counterparty))) {
         reject(new InvalidRequestError('Invalid parameter: base. Must be a currency string in the form currency+counterparty'));
       }
 
@@ -352,15 +352,15 @@ function getOrderBook(request, response, next) {
         reject(new InvalidRequestError('Invalid parameter: counter. Must be a currency string in the form currency+counterparty'));
       }
 
-      if (options.counter.currency !== 'XRP' && (!options.counter.issuer || !ripple.UInt160.is_valid(options.counter.issuer))) {
+      if (options.counter.currency !== 'XRP' && (!options.counter.counterparty || !ripple.UInt160.is_valid(options.counter.counterparty))) {
         reject(new InvalidRequestError('Invalid parameter: counter. Must be a currency string in the form currency+counterparty'));
       }
 
-      if (options.counter.currency === 'XRP' && options.counter.issuer) {
+      if (options.counter.currency === 'XRP' && options.counter.counterparty) {
         reject(new InvalidRequestError('Invalid parameter: counter. XRP cannot have counterparty'));
       }
 
-      if (options.base.currency === 'XRP' && options.base.issuer) {
+      if (options.base.currency === 'XRP' && options.base.counterparty) {
         reject(new InvalidRequestError('Invalid parameter: base. XRP cannot have counterparty'));
       }
 
@@ -387,8 +387,8 @@ function getOrderBook(request, response, next) {
   function getBookOffers(taker_gets, taker_pays, options) {
     var promise = new Promise(function (resolve, reject) {
       var bookOffersRequest = remote.requestBookOffers({
-        taker_gets: taker_gets,
-        taker_pays: taker_pays,
+        taker_gets: { currency: taker_gets.currency, issuer: taker_gets.counterparty },
+        taker_pays: { currency: taker_pays.currency, issuer: taker_pays.counterparty },
         ledger: options.ledger,
         limit: options.limit,
         taker: options.account

--- a/test/_payments-test.js
+++ b/test/_payments-test.js
@@ -435,11 +435,11 @@ suite('payments', function() {
       var statusPayment = {
         source_account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
         source_tag: '',
-        source_amount: { value: '200', currency: 'XRP', issuer: '' },
+        source_amount: { value: '200', currency: 'XRP', counterparty: '' },
         source_slippage: '0',
         destination_account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5',
         destination_tag: '',
-        destination_amount: { value: '200', currency: 'XRP', issuer: '' },
+        destination_amount: { value: '200', currency: 'XRP', counterparty: '' },
         invoice_id: '',
         paths: '[]',
         no_direct_ripple: false,
@@ -466,7 +466,6 @@ suite('payments', function() {
     .end(done);
   });
 
-  // confirm payment via transaction hash
   test('confirm payment via transaction hash', function(done) {
     orderlist.create([{command:'tx'}]);
     var _tx = function(data,ws) {
@@ -483,11 +482,11 @@ suite('payments', function() {
         var statusPayment = {
           source_account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
           source_tag: '',
-          source_amount: { value: '200', currency: 'XRP', issuer: '' },
+          source_amount: { value: '200', currency: 'XRP', counterparty: '' },
           source_slippage: '0',
           destination_account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5',
           destination_tag: '',
-          destination_amount: { value: '200', currency: 'XRP', issuer: '' },
+          destination_amount: { value: '200', currency: 'XRP', counterparty: '' },
           invoice_id: '',
           paths: '[]',
           no_direct_ripple: false,
@@ -772,7 +771,7 @@ suite('payments', function() {
               source_amount: {
                 value: '10',
                 currency: 'USD',
-                issuer: ''
+                counterparty: ''
               },
               source_slippage: '0',
               destination_account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5',
@@ -780,7 +779,7 @@ suite('payments', function() {
               destination_amount: {
                 value: '10',
                 currency: 'USD',
-                issuer: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U'
+                counterparty: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U'
               },
               invoice_id: '',
               paths: '[]',
@@ -808,7 +807,7 @@ suite('payments', function() {
         assert.deepEqual(resp.body,{ success: false,
           error_type: 'invalid_request',
           error: 'restINVALID_PARAMETER',
-          message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+issuer' })
+          message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+counterparty' })
         done()
       })
   });
@@ -820,7 +819,7 @@ suite('payments', function() {
         assert.deepEqual(resp.body,{ success: false,
           error_type: 'invalid_request',
           error: 'restINVALID_PARAMETER',
-          message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+issuer' })
+          message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+counterparty' })
         done()
       })
   });

--- a/test/fixtures/payments.js
+++ b/test/fixtures/payments.js
@@ -483,14 +483,14 @@ module.exports.RESTTransactionResponse = function(options) {
       source_amount: {
         value: '1.112209',
         currency: 'XRP',
-        issuer: ''
+        counterparty: ''
       },
       source_slippage: '0',
       destination_account: options.toAccount,
       destination_tag: '',
       destination_amount: {
         currency: 'USD',
-        issuer: options.toAccount,
+        counterparty: options.toAccount,
         value: '0.001'
       },
       invoice_id: '',
@@ -505,21 +505,21 @@ module.exports.RESTTransactionResponse = function(options) {
         {
           currency: 'XRP',
           value: '-1.101208',
-          issuer: ''
+          counterparty: ''
         }
       ],
       source_balance_changes: [
         {
           value: '-1.101208',
           currency: 'XRP',
-          issuer: ''
+          counterparty: ''
         }
       ],
       destination_balance_changes: [
         {
           value: '0.001',
           currency: 'USD',
-          issuer: addresses.COUNTERPARTY
+          counterparty: addresses.COUNTERPARTY
         }
       ],
       order_changes: [
@@ -563,14 +563,14 @@ module.exports.RESTAccountTransactionsResponse = function(options) {
           source_amount: {
             value: '1.112209',
             currency: 'XRP',
-            issuer: ''
+            counterparty: ''
           },
           source_slippage: '0',
           destination_account: options.toAccount,
           destination_tag: '',
           destination_amount: {
             currency: 'USD',
-            issuer: options.toAccount,
+            counterparty: options.toAccount,
             value: '0.001'
           },
           invoice_id: '',
@@ -585,21 +585,21 @@ module.exports.RESTAccountTransactionsResponse = function(options) {
             {
               currency: 'XRP',
               value: '-1.101208',
-              issuer: ''
+              counterparty: ''
             }
           ],
           source_balance_changes: [
             {
               value: '-1.101208',
               currency: 'XRP',
-              issuer: ''
+              counterparty: ''
             }
           ],
           destination_balance_changes: [
             {
               value: '0.001',
               currency: 'USD',
-              issuer: addresses.COUNTERPARTY
+              counterparty: addresses.COUNTERPARTY
             }
           ],
           order_changes: [
@@ -639,7 +639,7 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
       source_tag: '',
       source_amount: {
         currency: '0158415500000000C1F76FF6ECB0BAC600000000',
-        issuer: addresses.COUNTERPARTY,
+        counterparty: addresses.COUNTERPARTY,
         value: '0.00000001'
       },
       source_slippage: '0',
@@ -647,7 +647,7 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
       destination_tag: '',
       destination_amount: {
         currency: '0158415500000000C1F76FF6ECB0BAC600000000',
-        issuer: addresses.COUNTERPARTY,
+        counterparty: addresses.COUNTERPARTY,
         value: '0.00000001'
       },
       invoice_id: '',
@@ -662,31 +662,31 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
         {
           currency: 'XRP',
           value: '-0.012',
-          issuer: ''
+          counterparty: ''
         },
         {
           currency: '0158415500000000C1F76FF6ECB0BAC600000000',
           value: '-1e-8',
-          issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
+          counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
         }
       ],
       source_balance_changes: [
         {
           value: '-0.012',
           currency: 'XRP',
-          issuer: ''
+          counterparty: ''
         },
         {
           value: '-1e-8',
           currency: '0158415500000000C1F76FF6ECB0BAC600000000',
-          issuer: addresses.COUNTERPARTY
+          counterparty: addresses.COUNTERPARTY
         }
       ],
       destination_balance_changes: [
         {
           value: '1e-8',
           currency: '0158415500000000C1F76FF6ECB0BAC600000000',
-          issuer: addresses.VALID
+          counterparty: addresses.VALID
         }
       ],
       order_changes: []
@@ -705,22 +705,24 @@ module.exports.payment = function(options) {
     clientResourceId: '1',
     value: '1',
     currency: 'XRP',
-    issuer: ''
+    counterparty: '',
+    destinationAccount: addresses.COUNTERPARTY,
+    sourceAccount: addresses.VALID
   });
 
-  return { 
+  return {
     secret: options.secret,
     client_resource_id: options.clientResourceId,
     fixed_fee: options.fixed_fee ? String(options.fixed_fee) : undefined,
     max_fee: options.max_fee ? String(options.max_fee) : undefined,
     last_ledger_sequence: options.lastLedgerSequence,
     payment: {
-      source_account: addresses.VALID,
-      destination_account: addresses.COUNTERPARTY,
+      source_account: options.sourceAccount,
+      destination_account: options.destinationAccount,
       destination_amount: {
         value: options.value,
         currency: options.currency,
-        issuer: options.issuer
+        counterparty: options.counterparty
       },
       memos: options.memos
     }

--- a/test/orders-test.js
+++ b/test/orders-test.js
@@ -1621,6 +1621,7 @@ suite('get order book', function() {
   });
 
   test('v1/accounts/:account/order_book/:base/:counter -- with XRP as base', function(done) {
+
     self.wss.on('request_ledger', function(message, conn) {
       assert.strictEqual(message.ledger_index, 'validated');
       conn.send(fixtures.requestLedgerResponse(message, {

--- a/test/paths-test.js
+++ b/test/paths-test.js
@@ -76,7 +76,7 @@ suite('get payment paths', function() {
     .expect(testutils.checkBody(errors.RESTErrorResponse({
       type: 'invalid_request',
       error: 'restINVALID_PARAMETER',
-      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+issuer'
+      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+counterparty'
     })))
     .end(done);
   });
@@ -97,12 +97,12 @@ suite('get payment paths', function() {
     .expect(testutils.checkBody(errors.RESTErrorResponse({
       type: 'invalid_request',
       error: 'restINVALID_PARAMETER',
-      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+issuer'
+      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+counterparty'
     })))
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- invalid destination currency issuer', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- invalid destination currency counterparty', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert(false);
     });
@@ -118,12 +118,12 @@ suite('get payment paths', function() {
     .expect(testutils.checkBody(errors.RESTErrorResponse({
       type: 'invalid_request',
       error: 'restINVALID_PARAMETER',
-      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+issuer'
+      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+counterparty'
     })))
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- invalid IOU source currency without issuer', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- invalid IOU source currency without counterparty', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert(false);
     });
@@ -144,7 +144,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with invalid issuer', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with invalid counterparty', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert(false);
     });
@@ -165,7 +165,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with valid issuer', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with valid counterparty', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.VALID);
@@ -192,7 +192,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- multiple valid IOU source currencies with valid issuer', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- multiple valid IOU source currencies with valid counterparty', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.VALID);
@@ -244,7 +244,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- multiple source currencies with invalid last source currency issuer', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- multiple source currencies with invalid last source currency counterparty', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert(false);
     });
@@ -265,7 +265,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- XRP source amount response has source account, destination account, and destination amount issuer correctly set', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- XRP source amount response has source account, destination account, and destination amount counterparty correctly set', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.VALID);
@@ -289,7 +289,7 @@ suite('get payment paths', function() {
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.source_account, addresses.VALID);
         assert.strictEqual(paymentObj.destination_account, addresses.VALID);
-        assert.strictEqual(paymentObj.destination_amount.issuer, '');
+        assert.strictEqual(paymentObj.destination_amount.counterparty, '');
       });
 
       done();
@@ -322,14 +322,14 @@ suite('get payment paths', function() {
         _.each(res.body.payments, function(paymentObj) {
           assert.strictEqual(paymentObj.source_account, addresses.VALID);
           assert.strictEqual(paymentObj.destination_account, addresses.VALID);
-          assert.strictEqual(paymentObj.destination_amount.issuer, addresses.VALID);
+          assert.strictEqual(paymentObj.destination_amount.counterparty, addresses.VALID);
         });
 
         done();
       });
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- IOU destination amount response has source amount issuer set to alternative\'s source amount issuer but defaults to source account for all non-XRP source amounts', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- IOU destination amount response has source amount counterparty set to alternative\'s source amount counterparty but defaults to source account for all non-XRP source amounts', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.COUNTERPARTY);
@@ -350,9 +350,9 @@ suite('get payment paths', function() {
     .end(function(err, res) {
       if (err) return done(err);
 
-      assert.strictEqual(res.body.payments[0].source_amount.issuer, '');
-      assert.strictEqual(res.body.payments[1].source_amount.issuer, addresses.VALID);
-      assert.strictEqual(res.body.payments[2].source_amount.issuer, '');
+      assert.strictEqual(res.body.payments[0].source_amount.counterparty, '');
+      assert.strictEqual(res.body.payments[1].source_amount.counterparty, addresses.VALID);
+      assert.strictEqual(res.body.payments[2].source_amount.counterparty, '');
 
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.source_account, addresses.COUNTERPARTY);
@@ -363,7 +363,7 @@ suite('get payment paths', function() {
     });
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- IOU destination amount has source account, destination account, and destination amount issuer correctly set', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- IOU destination amount has source account, destination account, and destination amount counterparty correctly set', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.VALID);
@@ -381,7 +381,7 @@ suite('get payment paths', function() {
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.source_account, addresses.VALID);
         assert.strictEqual(paymentObj.destination_account, addresses.VALID);
-        assert.strictEqual(paymentObj.destination_amount.issuer, addresses.ISSUER);
+        assert.strictEqual(paymentObj.destination_amount.counterparty, addresses.ISSUER);
       });
 
       done();
@@ -404,7 +404,7 @@ suite('get payment paths', function() {
       if (err) return done(err);
 
       _.each(res.body.payments, function(paymentObj) {
-        assert.strictEqual(paymentObj.destination_amount.issuer, addresses.VALID);
+        assert.strictEqual(paymentObj.destination_amount.counterparty, addresses.VALID);
       });
 
       done();

--- a/test/unit/fixtures/rest-converter.js
+++ b/test/unit/fixtures/rest-converter.js
@@ -7,7 +7,7 @@ module.exports.paymentRest = {
   "destination_amount": {
     "value": "0.001",
     "currency": "USD",
-    "issuer": addresses.COUNTERPARTY
+    "counterparty": addresses.COUNTERPARTY
   }
 };
 
@@ -17,7 +17,7 @@ module.exports.paymentRestXRP = {
   "destination_amount": {
     "value": "1",
     "currency": "XRP",
-    "issuer": ""
+    "counterparty": ""
   }
 };
 
@@ -27,7 +27,7 @@ module.exports.paymentRestComplex = {
   "source_amount": {
     "value": "10",
     "currency": "USD",
-    "issuer": addresses.VALID
+    "counterparty": addresses.VALID
   },
   "source_slippage": "0",
   "destination_account": addresses.COUNTERPARTY,
@@ -35,7 +35,7 @@ module.exports.paymentRestComplex = {
   "destination_amount": {
     "value": "10",
     "currency": "USD",
-    "issuer": addresses.VALID
+    "counterparty": addresses.VALID
   },
   "invoice_id": "",
   "paths": "[]",
@@ -125,21 +125,21 @@ module.exports.exportsPaymentRestIssuers = function(options) {
     source_tag: '',
     source_amount: {
       value: options.sourceValue,
-        currency: 'USD',
-        issuer: options.sourceIssuer
+      currency: 'USD',
+      counterparty: options.sourceIssuer
     },
     source_slippage: options.sourceSlippage,
-      destination_account: options.destinationAccount,
-      destination_tag: '',
-      destination_amount: {
+    destination_account: options.destinationAccount,
+    destination_tag: '',
+    destination_amount: {
       value: '10',
-        currency: 'USD',
-        issuer: options.destinationIssuer
+      currency: 'USD',
+      counterparty: options.destinationIssuer
     },
     invoice_id: '',
-      paths: '[]',
-      partial_payment: false,
-      no_direct_ripple: false
+    paths: '[]',
+    partial_payment: false,
+    no_direct_ripple: false
   }
 
 };

--- a/test/unit/fixtures/tx-converter.js
+++ b/test/unit/fixtures/tx-converter.js
@@ -380,13 +380,13 @@ module.exports.paymentTx = function(options) {
 module.exports.paymentRest = {
   source_account: addresses.VALID,
   source_tag: '',
-  source_amount: { value: '1.112209', currency: 'XRP', issuer: '' },
+  source_amount: { value: '1.112209', currency: 'XRP', counterparty: '' },
   source_slippage: '0',
   destination_account: addresses.ISSUER,
   destination_tag: '',
   destination_amount:
   { currency: 'USD',
-    issuer: addresses.ISSUER,
+    counterparty: addresses.ISSUER,
     value: '0.001' },
   invoice_id: '',
   paths: '[[{"currency":"USD","issuer":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","type":48,"type_hex":"0000000000000030"},{"account":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","currency":"USD","issuer":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","type":49,"type_hex":"0000000000000031"}]]',
@@ -400,14 +400,14 @@ module.exports.paymentRest = {
     {
       currency: 'XRP',
       value: '-1.101208',
-      issuer: ''
+      counterparty: ''
     }
   ],
-  source_balance_changes: [ { value: '-1.101208', currency: 'XRP', issuer: '' } ],
+  source_balance_changes: [ { value: '-1.101208', currency: 'XRP', counterparty: '' } ],
   destination_balance_changes:
     [ { value: '0.001',
       currency: 'USD',
-      issuer: addresses.COUNTERPARTY } ],
+      counterparty: addresses.COUNTERPARTY } ],
   order_changes: [
     {
       taker_pays: {
@@ -736,7 +736,7 @@ module.exports.pathPaymentsRest = [
     "source_amount": {
       "value": "0.1117218827811721",
       "currency": "JPY",
-      "issuer": ""
+      "counterparty": ""
     },
     "source_slippage": "0",
     "destination_account": addresses.VALID,
@@ -744,7 +744,7 @@ module.exports.pathPaymentsRest = [
     "destination_amount": {
       "value": "100",
       "currency": "USD",
-      "issuer": addresses.ISSUER
+      "counterparty": addresses.ISSUER
     },
     "invoice_id": "",
     "paths": "[[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -757,7 +757,7 @@ module.exports.pathPaymentsRest = [
     "source_amount": {
       "value": "0.001002",
       "currency": "USD",
-      "issuer": ""
+      "counterparty": ""
     },
     "source_slippage": "0",
     "destination_account": addresses.VALID,
@@ -765,7 +765,7 @@ module.exports.pathPaymentsRest = [
     "destination_amount": {
       "value": "100",
       "currency": "USD",
-      "issuer": addresses.ISSUER
+      "counterparty": addresses.ISSUER
     },
     "invoice_id": "",
     "paths": "[[{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -778,7 +778,7 @@ module.exports.pathPaymentsRest = [
     "source_amount": {
       "value": "0.207669",
       "currency": "XRP",
-      "issuer": ""
+      "counterparty": ""
     },
     "source_slippage": "0",
     "destination_account": addresses.VALID,
@@ -786,7 +786,7 @@ module.exports.pathPaymentsRest = [
     "destination_amount": {
       "value": "100",
       "currency": "USD",
-      "issuer": addresses.ISSUER
+      "counterparty": addresses.ISSUER
     },
     "invoice_id": "",
     "paths": "[[{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rf9X8QoYnWLHMHuDfjkmRcD2UE5qX5aYV\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rfQPFZ3eLcaSUKjUy7A3LAmDNM4F9Hz9j1\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",

--- a/test/unit/rest-converter-test.js
+++ b/test/unit/rest-converter-test.js
@@ -29,7 +29,7 @@ suite('unit - converter - Rest to Tx', function() {
     });
   });
 
-  test('convert() -- payment with currency that has same issuer for source and destination amount', function(done) {
+  test('convert() -- payment with currency that has same counterpartes for source and destination amount', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
       sourceIssuer:  addresses.VALID,
       destinationIssuer: addresses.VALID
@@ -40,7 +40,7 @@ suite('unit - converter - Rest to Tx', function() {
     });
   });
 
-  test('convert() -- payment with currency that has different issuers for source and destination amount', function(done) {
+  test('convert() -- payment with currency that has different counterparties for source and destination amount', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
       sourceIssuer:  addresses.VALID,
       destinationIssuer: addresses.COUNTERPARTY
@@ -55,7 +55,7 @@ suite('unit - converter - Rest to Tx', function() {
     });
   });
 
-  test('convert() -- payment with currency that has different issuers for source and destination amount and a source_slippage of 0.1', function(done) {
+  test('convert() -- payment with currency that has different counterparties for source and destination amount and a source_slippage of 0.1', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
       sourceIssuer:  addresses.VALID,
       destinationIssuer: addresses.COUNTERPARTY,

--- a/test/unit/tx-converter-test.js
+++ b/test/unit/tx-converter-test.js
@@ -30,13 +30,13 @@ suite('unit - converter - Tx to Rest', function() {
       assert.strictEqual(err, null);
 
       assert.deepEqual(payment.source_balance_changes, [
-        { value: '-0.834999999999999', currency: 'EUR', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
-        { value: '-0.015', currency: 'XRP', issuer: '' }
+        { value: '-0.834999999999999', currency: 'EUR', counterparty: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
+        { value: '-0.015', currency: 'XRP', counterparty: '' }
       ]);
 
       assert.deepEqual(payment.destination_balance_changes, [
-        { value: '-1', currency: 'USD', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
-        { value: '0.833333333333', currency: 'EUR', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' }
+        { value: '-1', currency: 'USD', counterparty: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
+        { value: '0.833333333333', currency: 'EUR', counterparty: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' }
       ]);
 
       done();

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -94,21 +94,21 @@ suite('unit - utils.parseCurrencyQuery()', function() {
     assert.deepEqual(utils.parseCurrencyQuery('123+XRP'), {
       value: '123',
       currency: 'XRP',
-      issuer: ''
+      counterparty: ''
     });
   });
 
   test('parseCurrencyQuery() -- XRP', function() {
     assert.deepEqual(utils.parseCurrencyQuery('XRP'), {
       currency: 'XRP',
-      issuer: ''
+      counterparty: ''
     });
   });
 
   test('parseCurrencyQuery() -- USD', function() {
     assert.deepEqual(utils.parseCurrencyQuery('USD'), {
       currency: 'USD',
-      issuer: ''
+      counterparty: ''
     });
   });
 
@@ -116,44 +116,44 @@ suite('unit - utils.parseCurrencyQuery()', function() {
     assert.deepEqual(utils.parseCurrencyQuery('123+USD'), {
       value: '123',
       currency: 'USD',
-      issuer: ''
+      counterparty: ''
     });
   });
 
-  test('parseCurrencyQuery() -- USD+issuer', function() {
+  test('parseCurrencyQuery() -- USD+counterparty', function() {
     assert.deepEqual(utils.parseCurrencyQuery('USD+' + addresses.VALID), {
       currency: 'USD',
-      issuer: addresses.VALID
+      counterparty: addresses.VALID
     });
   });
 
-  test('parseCurrencyQuery() -- 123+USD+issuer', function() {
+  test('parseCurrencyQuery() -- 123+USD+counterparty', function() {
     assert.deepEqual(utils.parseCurrencyQuery('123+USD+' + addresses.VALID), {
       value: '123',
       currency: 'USD',
-      issuer: addresses.VALID
+      counterparty: addresses.VALID
     });
   });
 
-  test('parseCurrencyQuery() -- XRP+issuer', function() {
+  test('parseCurrencyQuery() -- XRP+counterparty', function() {
     assert.deepEqual(utils.parseCurrencyQuery('XRP+' + addresses.VALID), {
       currency: 'XRP',
-      issuer: addresses.VALID
+      counterparty: addresses.VALID
     });
   });
 
-  test('parseCurrencyQuery() -- 123+XRP+issuer', function() {
+  test('parseCurrencyQuery() -- 123+XRP+counterparty', function() {
     assert.deepEqual(utils.parseCurrencyQuery('123+XRP+' + addresses.VALID), {
       value: '123',
       currency: 'XRP',
-      issuer: addresses.VALID
+      counterparty: addresses.VALID
     });
   });
 
   test('parseCurrencyQuery() -- XRP+', function() {
     assert.deepEqual(utils.parseCurrencyQuery('XRP+'), {
       currency: 'XRP',
-      issuer: ''
+      counterparty: ''
     });
   });
 
@@ -161,7 +161,7 @@ suite('unit - utils.parseCurrencyQuery()', function() {
     assert.deepEqual(utils.parseCurrencyQuery('123+XRP+'), {
       value: '123',
       currency: 'XRP',
-      issuer: ''
+      counterparty: ''
     });
   });
 
@@ -169,7 +169,34 @@ suite('unit - utils.parseCurrencyQuery()', function() {
     assert.deepEqual(utils.parseCurrencyQuery('123'), {
       value: '123',
       currency: '',
-      issuer: ''
+      counterparty: ''
+    });
+  });
+});
+
+suite('unit - utils.txFromRestAmount()', function() {
+
+  test('txFromRestAmount() -- XRP', function() {
+    var amount = {
+      value: '1',
+      currency: 'XRP',
+      counterparty: ''
+    };
+
+    assert.strictEqual(utils.txFromRestAmount(amount), '1000000');
+  });
+
+  test('txFromRestAmount() -- USD', function() {
+    var amount = {
+      value: '1',
+      currency: 'USD',
+      counterparty: addresses.COUNTERPARTY
+    };
+
+    assert.deepEqual(utils.txFromRestAmount(amount), {
+      value: '1',
+      currency: 'USD',
+      issuer: addresses.COUNTERPARTY
     });
   });
 });


### PR DESCRIPTION
- This completes the conversion of all APIs in REST from using `issuer`
  to `counterparty`