### PR TITLE
[FEATURE] Production logs in ELF format (RLJS-239)

### DIFF
--- a/api/lib/logger.js
+++ b/api/lib/logger.js
@@ -7,30 +7,13 @@ var logger = new winston.Logger({
       prettyPrint: true,
       colorize: true,
       timestamp: true,
-      handleExceptions: true
+      handleExceptions: true,
+      logLevel: 'info',
+      showLevel: true,
+      silent: config.get('NODE_ENV') === 'test'
     })
-  ]
+  ],
+  exitOnError: false
 });
 
-var loggerStream = {write: function (data) {
-  logger.info(data.replace(/\n$/, ''));
-}};
-
-var logInfo = logger.info;
-
-logger.info = function() {
-  if (config.get('NODE_ENV') !== 'test') {
-    logInfo.apply(logger, arguments);
-  }
-};
-
-var logError = logger.error;
-
-logger.error = function() {
-  if (config.get('NODE_ENV') !== 'test') {
-    logError.apply(logger, arguments);
-  }
-};
-
 exports.logger = logger;
-exports.loggerStream = loggerStream;

--- a/server/express_app.js
+++ b/server/express_app.js
@@ -1,8 +1,8 @@
 const ripple     = require('ripple-lib');
 const express    = require('express');
 const bodyParser = require('body-parser');
-const morgan     = require('morgan');
-const logger     = require('./logger.js');
+const logger     = require('./logger.js').logger;
+const morgan     = require('./logger.js').morgan;
 const config     = require('../api/lib/config');
 const router     = require('./router.js');
 const version    = require('./version.js');
@@ -24,13 +24,11 @@ app.use(function(req, res, next) {
   next();
 });
 
-if (config.get('NODE_ENV') !== 'test') {
-  app.use(morgan('dev', { stream: logger.loggerStream }));
-}
+morgan(app);
 
 if (config.get('debug')) {
   app.use(function (req, res, next) {
-    logger.logger.info(req.method, req.url, req.body);
+    logger.info(req.method, req.url, req.body);
     next();
   })
 }


### PR DESCRIPTION
- Use ELF Format for production express logs
See: http://www.w3.org/TR/WD-logfile

```
#Version: 1.0
#Date: 2015-02-20 01:08:16
#Software: 1.4.0
#Fields: c-ip date time cs-method cs-uri cs(Version) sc-status time-taken cs(User-Agent)
127.0.0.1 2015-02-20 01:08:18 GET /v1 1.1 304 4.612 Mozilla/5.0+(Macintosh;+Intel+Mac+OS+X+10_10_2)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/40.0.2214.111+Safari/537.36
```