### PR TITLE
[FIX] Notifications: Sort transactions on Sequence (RLJS-253)

### DIFF
--- a/api/lib/notification_parser.js
+++ b/api/lib/notification_parser.js
@@ -39,9 +39,8 @@ NotificationParser.prototype.parse = function(notification_details) {
     client_resource_id: notification_details.client_resource_id
   };
 
-  notification.timestamp = new Date(
-    ripple.utils.time.fromRipple(transaction.date)
-  ).toISOString();
+  notification.timestamp = transaction.date ?
+    new Date(ripple.utils.time.fromRipple(transaction.date)).toISOString() : '';
 
   if (account === transaction.Account) {
     notification.direction = 'outgoing';

--- a/api/notifications.js
+++ b/api/notifications.js
@@ -217,7 +217,7 @@ function attachPreviousAndNextTransactionIdentifiers(notificationDetails, callba
     // Sort transactions in ascending order (earliestFirst) by ledger_index
     transactions.sort(function(a, b) {
       if (a.ledger_index === b.ledger_index) {
-        return a.date <= b.date ? -1 : 1;
+        return a.Sequence <= b.Sequence ? -1 : 1;
       } else {
         return a.ledger_index < b.ledger_index ? -1 : 1;
       }

--- a/test/fixtures/notifications.js
+++ b/test/fixtures/notifications.js
@@ -46,7 +46,6 @@ var BINARY_TRANSACTION = module.exports.BINARY_TRANSACTION = {
 };
 
 var BINARY_TRANSACTION_SYNTH = module.exports.BINARY_TRANSACTION_SYNTH = {
-  date: 416447810,
   hash: 'F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF',
   inLedger: LEDGER,
   ledger_index: LEDGER
@@ -250,6 +249,34 @@ module.exports.serverInfoResponse = function(request) {
   });
 };
 
+module.exports.ledgerResponse = function(request) {
+  return JSON.stringify(
+    {
+      id: request.id,
+      status: 'success',
+      type: 'response',
+      result: {
+        ledger: {
+          accepted: true,
+          account_hash: 'EC028EC32896D537ECCA18D18BEBE6AE99709FEFF9EF72DBD3A7819E918D8B96',
+          close_time: 464908910,
+          close_time_human: '2014-Sep-24 21:21:50',
+          close_time_resolution: 10,
+          closed: true,
+          hash: '0F7ED9F40742D8A513AE86029462B7A6768325583DF8EE21B7EC663019DD6A0F',
+          ledger_hash: '0F7ED9F40742D8A513AE86029462B7A6768325583DF8EE21B7EC663019DD6A0F',
+          ledger_index: '9038214',
+          parent_hash: '4BB9CBE44C39DC67A1BE849C7467FE1A6D1F73949EA163C38A0121A15E04FFDE',
+          seqNum: '9038214',
+          totalCoins: '99999973964317514',
+          total_coins: '99999973964317514',
+          transaction_hash: 'ECB730839EB55B1B114D5D1AD2CD9A932C35BA9AB6D3A8C2F08935EAC2BAC239'
+        }
+      }
+    }
+  );
+};
+
 module.exports.serverInfoMissingLedgerResponse = function(request) {
   return JSON.stringify({
     id: request.id,
@@ -377,7 +404,7 @@ module.exports.RESTNotificationResponse = JSON.stringify({
     result: 'tesSUCCESS',
     ledger: String(LEDGER),
     hash: 'F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF',
-    timestamp: '2013-03-12T23:56:50.000Z',
+    timestamp: '2014-09-24T21:21:50.000Z',
     transaction_url: 'http://127.0.0.1:5990/v1/accounts/' + addresses.VALID + '/payments/F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF',
     previous_hash: 'BACD1473E1D778CE38AD6D7C671D519506D0BC33AE3C54FA5A59D9C9161C381B',
     previous_notification_url: 'http://127.0.0.1:5990/v1/accounts/' + addresses.VALID + '/notifications/BACD1473E1D778CE38AD6D7C671D519506D0BC33AE3C54FA5A59D9C9161C381B',
@@ -396,7 +423,7 @@ module.exports.RESTNotificationNoNextResponse = JSON.stringify({
     result: 'tesSUCCESS',
     ledger: String(LEDGER),
     hash: 'F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF',
-    timestamp: '2013-03-12T23:56:50.000Z',
+    timestamp: '2014-09-24T21:21:50.000Z',
     transaction_url: 'http://127.0.0.1:5990/v1/accounts/' + addresses.VALID + '/payments/F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF',
     previous_hash: 'BACD1473E1D778CE38AD6D7C671D519506D0BC33AE3C54FA5A59D9C9161C381B',
     previous_notification_url: 'http://127.0.0.1:5990/v1/accounts/' + addresses.VALID + '/notifications/BACD1473E1D778CE38AD6D7C671D519506D0BC33AE3C54FA5A59D9C9161C381B',

--- a/test/notifications-test.js
+++ b/test/notifications-test.js
@@ -29,6 +29,11 @@ suite('get notifications', function() {
       conn.send(fixtures.serverInfoResponse(message));
     });
 
+    self.wss.once('request_ledger', function(message, conn) {
+      assert.strictEqual(message.command, 'ledger');
+      conn.send(fixtures.ledgerResponse(message));
+    });
+
     function handleLedgerQuery(message, conn) {
       assert.strictEqual(message.command, 'account_tx');
       assert.strictEqual(message.account, addresses.VALID);
@@ -83,6 +88,11 @@ suite('get notifications', function() {
     self.wss.once('request_server_info', function(message, conn) {
       assert.strictEqual(message.command, 'server_info');
       conn.send(fixtures.serverInfoResponse(message));
+    });
+
+    self.wss.once('request_ledger', function(message, conn) {
+      assert.strictEqual(message.command, 'ledger');
+      conn.send(fixtures.ledgerResponse(message));
     });
 
     function handleLedgerQuery(message, conn) {
@@ -146,6 +156,11 @@ suite('get notifications', function() {
     };
 
     self.wss.once('request_account_tx', handleLedgerQuery);
+
+    self.wss.once('request_ledger', function(message, conn) {
+      assert.strictEqual(message.command, 'ledger');
+      conn.send(fixtures.ledgerResponse(message));
+    });
 
     self.app
     .get(fixtures.requestPath(addresses.VALID, '/' + VALID_TRANSACTION_HASH))


### PR DESCRIPTION
- When requesting transactions in binary format, rippled does not
  provide `date`
- To determinstically sort transactions in the same ledger, sort based
  on `Sequence`