### PR TITLE
[FIX] Notifications: Sort transcations on `meta.TransactionIndex`

### DIFF
--- a/api/lib/utils.js
+++ b/api/lib/utils.js
@@ -13,7 +13,8 @@ module.exports = {
   parseLedger: parseLedger,
   parseCurrencyAmount: parseCurrencyAmount,
   parseCurrencyQuery: parseCurrencyQuery,
-  txFromRestAmount: txFromRestAmount
+  txFromRestAmount: txFromRestAmount,
+  compareTransactions: compareTransactions
 };
 
 function dropsToXrp(drops) {
@@ -104,3 +105,22 @@ function parseCurrencyQuery(query) {
     };
   }
 }
+
+/**
+ *  Order two rippled transactions based on their ledger_index.
+ *  If two transactions took place in the same ledger, sort
+ *  them based on TransactionIndex
+ *  See: https://ripple.com/build/transactions/
+ *
+ *  @param {Object} first
+ *  @param {Object} second
+ *  @returns {Number} [-1, 1]
+ */
+function compareTransactions(first, second) {
+  if (first.ledger_index === second.ledger_index) {
+    return first.meta.TransactionIndex < second.meta.TransactionIndex ? -1 : 1;
+  } else {
+    return first.ledger_index < second.ledger_index ? -1 : 1;
+  }
+}
+

--- a/api/notifications.js
+++ b/api/notifications.js
@@ -214,14 +214,7 @@ function attachPreviousAndNextTransactionIdentifiers(notificationDetails, callba
       return tx.hash;
     });
 
-    // Sort transactions in ascending order (earliestFirst) by ledger_index
-    transactions.sort(function(a, b) {
-      if (a.ledger_index === b.ledger_index) {
-        return a.Sequence <= b.Sequence ? -1 : 1;
-      } else {
-        return a.ledger_index < b.ledger_index ? -1 : 1;
-      }
-    });
+    transactions.sort(utils.compareTransactions);
 
     async_callback(null, transactions);
   }

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -200,3 +200,36 @@ suite('unit - utils.txFromRestAmount()', function() {
     });
   });
 });
+
+
+suite('unit - utils.compareTransactions()', function() {
+  test('compareTransactions() -- different ledgers', function() {
+    var tx1 = {
+      ledger_index: '1'
+    };
+
+    var tx2 = {
+      ledger_index: '2'
+    };
+
+    assert.deepEqual(utils.compareTransactions(tx1,tx2), -1);
+  });
+
+  test('compareTransactions() -- same ledger', function() {
+    var tx1 = {
+      ledger_index: 1,
+      meta: {
+        TransactionIndex: 2
+      }
+    };
+
+    var tx2 = {
+      ledger_index: 1,
+      meta: {
+        TransactionIndex: 1
+      }
+    };
+
+    assert.deepEqual(utils.compareTransactions(tx1,tx2), 1);
+  });
+});


### PR DESCRIPTION
(RLJS-253)

- Previous fix was incorrectly sorting on Sequence, but that can only
  sort transactions submitted by the same account