### PR TITLE
[TASK] Fix ripple-lib deprecation warnings (RLJS-266)

### DIFF
--- a/api/transactions.js
+++ b/api/transactions.js
@@ -288,7 +288,7 @@ function getTransaction(account, identifier, callback) {
 
       // Request transaction based on either the hash supplied in the request
       // or the hash found in the database
-      remote.requestTx(requestHash || dbEntryHash, function(error, transaction) {
+      remote.requestTx({ hash: requestHash || dbEntryHash }, function(error, transaction) {
         if (error) {
           return async_callback(error);
         }


### PR DESCRIPTION
From `Remote` in ripple-lib:

`DEPRECATED: First argument to request constructor should be an object
containing request properties`