### PR TITLE
Revert "[TASK] Payments: Use `counterparty` in place of `issuer`"

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Example error:
     "success": false,
     "error_type": "invalid_request",
     "error": "Invalid parameter: destination_amount",
-    "message": "Non-XRP payment must have a counterparty"
+    "message": "Non-XRP payment must have an issuer"
 }
 ```
 
@@ -407,7 +407,7 @@ An example Payment object looks like this:
     "source_amount": {
         "value": "0.001",
         "currency": "XRP",
-        "counterparty": ""
+        "issuer": ""
     },
     "source_slippage": "0",
     "destination_address": "rNw4ozCG514KEjPs5cDrqEcdsi31Jtfm5r",
@@ -415,7 +415,7 @@ An example Payment object looks like this:
     "destination_amount": {
         "value": "0.001",
         "currency": "XRP",
-        "counterparty": ""
+        "issuer": ""
     },
     "invoice_id": "",
     "paths": "[]",
@@ -891,7 +891,7 @@ You can then choose one of the returned payment objects, modify it as desired (f
       "source_amount": {
         "value": "1.008413509923106",
         "currency": "USD",
-        "counterparty": ""
+        "issuer": ""
       },
       "source_slippage": "0",
       "destination_account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
@@ -899,7 +899,7 @@ You can then choose one of the returned payment objects, modify it as desired (f
       "destination_amount": {
         "value": "1",
         "currency": "USD",
-        "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
       },
       "invoice_id": "",
       "paths": "[[{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -912,7 +912,7 @@ You can then choose one of the returned payment objects, modify it as desired (f
       "source_amount": {
         "value": "61.06103",
         "currency": "XRP",
-        "counterparty": ""
+        "issuer": ""
       },
       "source_slippage": "0",
       "destination_account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
@@ -920,7 +920,7 @@ You can then choose one of the returned payment objects, modify it as desired (f
       "destination_amount": {
         "value": "1",
         "currency": "USD",
-        "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
       },
       "invoice_id": "",
       "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rpDMez6pm6dBve2TJsmDpv7Yae6V5Pyvy2\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpDMez6pm6dBve2TJsmDpv7Yae6V5Pyvy2\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rHAwwozJw6FHfnJfRQaFXrkGHocGoaNYSy\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rEtr3Kzh5MmhPbeNu6PDtQZsKBpgFEEEo5\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rKvPTQrD8ap1Y8TSmKjcK6G7q7Kvx7RAqQ\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -961,7 +961,7 @@ POST /v1/accounts/{address}/payments?validated=true
     "source_amount": {
       "value": "5.01",
       "currency": "USD",
-      "counterparty": ""
+      "issuer": ""
     },
     "source_slippage": "0",
     "destination_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -969,7 +969,7 @@ POST /v1/accounts/{address}/payments?validated=true
     "destination_amount": {
       "value": "5",
       "currency": "USD",
-      "counterparty": ""
+      "issuer": ""
     },
     "invoice_id": "",
     "paths": "[[{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -1070,7 +1070,7 @@ The following URL parameters are required by this API endpoint:
     "source_amount": {
       "value": "0.00001",
       "currency": "XRP",
-      "counterparty": ""
+      "issuer": ""
     },
     "source_slippage": "0",
     "destination_account": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
@@ -1078,7 +1078,7 @@ The following URL parameters are required by this API endpoint:
     "destination_amount": {
       "value": "0.00000005080000000000001",
       "currency": "USD",
-      "counterparty": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"
+      "issuer": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"
     },
     "invoice_id": "",
     "paths": "[]",
@@ -1187,7 +1187,7 @@ Optionally, you can also include the following query parameters:
       "source_amount": {
         "value": "20",
         "currency": "XRP",
-        "counterparty": ""
+        "issuer": ""
       },
       "source_slippage": "0",
       "destination_account": "raKEEVSGnKSD9Zyvxu4z6Pqpm4ABH8FS6n",
@@ -1195,7 +1195,7 @@ Optionally, you can also include the following query parameters:
       "destination_amount": {
         "value": "20",
         "currency": "XRP",
-        "counterparty": ""
+        "issuer": ""
       },
       "invoice_id": "",
       "paths": "[]",

--- a/api/lib/rest-to-tx-converter.js
+++ b/api/lib/rest-to-tx-converter.js
@@ -20,25 +20,25 @@ function RestToTxConverter() {}
  */
 RestToTxConverter.prototype.convert = function(payment, callback) {
   try {
-    // Convert blank counterparty to sender's address
-    //   (Ripple convention for 'any counterparty')
+    // Convert blank issuer to sender's address
+    //   (Ripple convention for 'any issuer')
     // https://ripple.com/build/transactions/
     //    #special-issuer-values-for-sendmax-and-amount
     // https://ripple.com/build/ripple-rest/#counterparties-in-payments
     if (payment.source_amount && payment.source_amount.currency !== 'XRP'
-        && payment.source_amount.counterparty === '') {
-      payment.source_amount.counterparty = payment.source_account;
+        && payment.source_amount.issuer === '') {
+      payment.source_amount.issuer = payment.source_account;
     }
 
-    // Convert blank counterparty to destinations's address
-    //   (Ripple convention for 'any counterparty')
+    // Convert blank issuer to destinations's address
+    //   (Ripple convention for 'any issuer')
     // https://ripple.com/build/transactions/
     //    #special-issuer-values-for-sendmax-and-amount
     // https://ripple.com/build/ripple-rest/#counterparties-in-payments
     if (payment.destination_amount
         && payment.destination_amount.currency !== 'XRP'
-        && payment.destination_amount.counterparty === '') {
-      payment.destination_amount.counterparty = payment.destination_account;
+        && payment.destination_amount.issuer === '') {
+      payment.destination_amount.issuer = payment.destination_account;
     }
     // Uppercase currency codes
     if (payment.source_amount) {
@@ -75,8 +75,8 @@ RestToTxConverter.prototype.convert = function(payment, callback) {
       // Only set send max if source and destination currencies are different
       if (!(payment.source_amount.currency
             === payment.destination_amount.currency
-            && payment.source_amount.counterparty
-            === payment.destination_amount.counterparty)) {
+            && payment.source_amount.issuer
+            === payment.destination_amount.issuer)) {
         var max_value = bignum(payment.source_amount.value)
                         .plus(payment.source_slippage || 0).toString();
         if (payment.source_amount.currency === 'XRP') {
@@ -85,7 +85,7 @@ RestToTxConverter.prototype.convert = function(payment, callback) {
           transaction.sendMax({
             value: max_value,
             currency: payment.source_amount.currency,
-            issuer: payment.source_amount.counterparty
+            issuer: payment.source_amount.issuer
           });
         }
       }

--- a/api/lib/tx-to-rest-converter.js
+++ b/api/lib/tx-to-rest-converter.js
@@ -14,7 +14,7 @@ function TxToRestConverter() {}
 // This is just to support the legacy naming of "counterparty", this
 // function should be removed when "issuer" is eliminated
 function renameCounterpartyToIssuer(orderChanges) {
-  return  _.mapValues(orderChanges, function(changes) {
+  return _.mapValues(orderChanges, function(changes) {
     return _.map(changes, function(change) {
 
       var converted;
@@ -228,7 +228,8 @@ TxToRestConverter.prototype.parseOrderFromTx = function(tx, options) {
       ? parseBalanceChanges(tx.meta)[options.account] || [] : [];
     var timestamp = tx.date
       ? new Date(ripple.utils.toTimestamp(tx.date)).toISOString() : '';
-    var order_changes = tx.meta ? parseOrderBookChanges(tx.meta)[options.account] : [];
+    var order_changes = tx.meta ?
+      parseOrderBookChanges(tx.meta)[options.account] : [];
 
     var direction;
     if (options.account === tx.Account) {

--- a/api/lib/utils.js
+++ b/api/lib/utils.js
@@ -36,14 +36,21 @@ function parseCurrencyAmount(rippledAmount, useIssuer) {
   var amount = {};
 
   if (typeof rippledAmount === 'string') {
-      amount.currency = 'XRP';
-      useIssuer ? amount.issuer = '' : amount.counterparty = '';
-      amount.value =  dropsToXrp(rippledAmount)
+    amount.currency = 'XRP';
+    amount.value = dropsToXrp(rippledAmount);
+    if (useIssuer) {
+      amount.issuer = '';
+    } else {
+      amount.counterparty = '';
+    }
   } else {
     amount.currency = rippledAmount.currency;
-    useIssuer ?  amount.issuer = rippledAmount.issuer
-      : amount.counterparty = rippledAmount.issuer;
     amount.value = rippledAmount.value;
+    if (useIssuer) {
+      amount.issuer = rippledAmount.issuer;
+    } else {
+      amount.counterparty = rippledAmount.issuer;
+    }
   }
 
   return amount;

--- a/api/lib/utils.js
+++ b/api/lib/utils.js
@@ -32,19 +32,21 @@ function parseLedger(ledger) {
   return 'validated';
 }
 
-function parseCurrencyAmount(rippledAmount) {
+function parseCurrencyAmount(rippledAmount, useIssuer) {
+  var amount = {};
+
   if (typeof rippledAmount === 'string') {
-    return {
-      currency: 'XRP',
-      counterparty: '',
-      value: dropsToXrp(rippledAmount)
-    };
+      amount.currency = 'XRP';
+      useIssuer ? amount.issuer = '' : amount.counterparty = '';
+      amount.value =  dropsToXrp(rippledAmount)
+  } else {
+    amount.currency = rippledAmount.currency;
+    useIssuer ?  amount.issuer = rippledAmount.issuer
+      : amount.counterparty = rippledAmount.issuer;
+    amount.value = rippledAmount.value;
   }
-  return {
-    currency: rippledAmount.currency,
-    counterparty: rippledAmount.issuer,
-    value: rippledAmount.value
-  };
+
+  return amount;
 }
 
 function txFromRestAmount(restAmount) {
@@ -53,7 +55,8 @@ function txFromRestAmount(restAmount) {
   }
   return {
     currency: restAmount.currency,
-    issuer: restAmount.counterparty,
+    issuer: restAmount.counterparty ?
+      restAmount.counterparty : restAmount.issuer,
     value: restAmount.value
   };
 }

--- a/api/payments.js
+++ b/api/payments.js
@@ -374,7 +374,7 @@ function getPayment(account, identifier, callback) {
     }
     if (!validator.isValid(identifier, 'Hash256') &&
       !validator.isValid(identifier, 'ResourceId')) {
-        invalid = 'Invalid Parameter: hash or client_resource_id. Must '
+      invalid = 'Invalid Parameter: hash or client_resource_id. Must '
         + 'provide a transaction hash or client_resource_id to get payment '
         + 'details';
     }
@@ -397,7 +397,7 @@ function getPayment(account, identifier, callback) {
   var steps = [
     validateOptions,
     getTransaction,
-    function (transaction, _callback) {
+    function(transaction, _callback) {
       return formatPaymentHelper(account, transaction, _callback);
     }
   ];
@@ -487,7 +487,7 @@ function getAccountPayments(account, source_account, destination_account,
       return _callback(null);
     }
     async.map(_transactions,
-      function (transaction, async_map_callback) {
+      function(transaction, async_map_callback) {
         return formatPaymentHelper(account, transaction, async_map_callback);
       },
       _callback
@@ -629,7 +629,7 @@ function getPathFind(source_account, destination_account,
           return;
         }
       } else if (validator.isValid(sourceCurrencyStrings[c], 'Currency')) {
-          source_currencies.push({currency: sourceCurrencyStrings[c]});
+        source_currencies.push({currency: sourceCurrencyStrings[c]});
       } else {
         callback(new InvalidRequestError('Invalid parameter: '
           + 'source_currencies. Must be a list of valid currencies'));

--- a/api/payments.js
+++ b/api/payments.js
@@ -180,18 +180,18 @@ function submitPayment(account, payment, clientResourceID, secret,
           'Invalid parameter: source_amount. Must be a valid Amount object'));
     }
 
-    // No counterparty for XRP
+    // No issuer for XRP
     if (payment.destination_amount
         && payment.destination_amount.currency.toUpperCase() === 'XRP'
-        && payment.destination_amount.counterparty) {
+        && payment.destination_amount.issuer) {
       return _callback(new InvalidRequestError(
-        'Invalid parameter: destination_amount. XRP cannot have counterparty'));
+        'Invalid parameter: destination_amount. XRP cannot have issuer'));
     }
     if (payment.source_amount
         && payment.source_amount.currency.toUpperCase() === 'XRP'
-        && payment.source_amount.counterparty) {
+        && payment.source_amount.issuer) {
       return _callback(new InvalidRequestError(
-        'Invalid parameter: source_amount. XRP cannot have counterparty'));
+        'Invalid parameter: source_amount. XRP cannot have issuer'));
     }
 
     // Slippage
@@ -576,11 +576,13 @@ function getPathFind(source_account, destination_account,
   // Parse destination amount
   if (!destination_amount_string) {
     callback(new InvalidRequestError('Missing parameter: destination_amount. '
-      + 'Must be an amount string in the form value+currency+counterparty'));
+      + 'Must be an amount string in the form value+currency+issuer'));
     return;
   }
 
-  var destination_amount = utils.parseCurrencyQuery(destination_amount_string);
+  var _destination_amount = utils.parseCurrencyQuery(destination_amount_string);
+  var destination_amount = _.omit(_destination_amount, 'counterparty');
+  destination_amount.issuer = _destination_amount.counterparty;
 
   if (!ripple.UInt160.is_valid(source_account)) {
     callback(new InvalidRequestError(
@@ -596,14 +598,14 @@ function getPathFind(source_account, destination_account,
 
   if (!validator.isValid(destination_amount, 'Amount')) {
     callback(new InvalidRequestError('Invalid parameter: destination_amount. '
-      + 'Must be an amount string in the form value+currency+counterparty'));
+      + 'Must be an amount string in the form value+currency+issuer'));
     return;
   }
 
   var source_currencies = [];
   // Parse source currencies
   // Note that the source_currencies should be in the form
-  // "USD r...,BTC,XRP". The counterparty is optional but if provided should be
+  // "USD r...,BTC,XRP". The issuer is optional but if provided should be
   // separated from the currency by a single space.
   if (source_currency_strings) {
     var sourceCurrencyStrings = source_currency_strings.split(',');
@@ -613,10 +615,10 @@ function getPathFind(source_account, destination_account,
                                                         /(^[ ])|([ ]$)/g, '');
       // If there is a space, there should be a valid issuer after the space
       if (/ /.test(sourceCurrencyStrings[c])) {
-        var currencyCounterpartyArray = sourceCurrencyStrings[c].split(' ');
+        var currencyIssuerArray = sourceCurrencyStrings[c].split(' ');
         var currencyObject = {
-          currency: currencyCounterpartyArray[0],
-          issuer: currencyCounterpartyArray[1]
+          currency: currencyIssuerArray[0],
+          issuer: currencyIssuerArray[1]
         };
         if (validator.isValid(currencyObject.currency, 'Currency')
             && ripple.UInt160.is_valid(currencyObject.issuer)) {

--- a/test/_payments-test.js
+++ b/test/_payments-test.js
@@ -463,11 +463,11 @@ suite('payments', function() {
       var statusPayment = {
         source_account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
         source_tag: '',
-        source_amount: {value: '200', currency: 'XRP', counterparty: ''},
+        source_amount: {value: '200', currency: 'XRP', issuer: ''},
         source_slippage: '0',
         destination_account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5',
         destination_tag: '',
-        destination_amount: {value: '200', currency: 'XRP', counterparty: ''},
+        destination_amount: {value: '200', currency: 'XRP', issuer: ''},
         invoice_id: '',
         paths: '[]',
         no_direct_ripple: false,
@@ -512,11 +512,11 @@ suite('payments', function() {
         var statusPayment = {
           source_account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
           source_tag: '',
-          source_amount: {value: '200', currency: 'XRP', counterparty: ''},
+          source_amount: {value: '200', currency: 'XRP', issuer: ''},
           source_slippage: '0',
           destination_account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5',
           destination_tag: '',
-          destination_amount: {value: '200', currency: 'XRP', counterparty: ''},
+          destination_amount: {value: '200', currency: 'XRP', issuer: ''},
           invoice_id: '',
           paths: '[]',
           no_direct_ripple: false,
@@ -828,7 +828,7 @@ suite('payments', function() {
               source_amount: {
                 value: '10',
                 currency: 'USD',
-                counterparty: ''
+                issuer: ''
               },
               source_slippage: '0',
               destination_account: 'rwmityd4Ss34DBUsRy7Pacv6UA5n7yjfe5',
@@ -836,7 +836,7 @@ suite('payments', function() {
               destination_amount: {
                 value: '10',
                 currency: 'USD',
-                counterparty: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U'
+                issuer: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U'
               },
               invoice_id: '',
               paths: '[]',
@@ -870,7 +870,7 @@ suite('payments', function() {
           error_type: 'invalid_request',
           error: 'restINVALID_PARAMETER',
           message: 'Invalid parameter: destination_amount. Must be an amount '
-            + 'string in the form value+currency+counterparty'
+            + 'string in the form value+currency+issuer'
         });
         done();
       });
@@ -889,7 +889,7 @@ suite('payments', function() {
           error_type: 'invalid_request',
           error: 'restINVALID_PARAMETER',
           message: 'Invalid parameter: destination_amount. Must be an amount '
-            + 'string in the form value+currency+counterparty'
+            + 'string in the form value+currency+issuer'
         });
         done();
       });

--- a/test/_payments-test.js
+++ b/test/_payments-test.js
@@ -13,16 +13,16 @@ var testutils = { };
 
 // check if obj has keys
 testutils.hasKeys = function(obj, keys) {
-    var list = Object.keys(obj);
-    var hasAllKeys = true;
-    var missing = {};
-    keys.forEach(function(key) {
-        if (list.indexOf(key) === -1) {
-            hasAllKeys = false;
-            missing[key] = true;
-        }
-    });
-    return {hasAllKeys: hasAllKeys, missing: missing};
+  var list = Object.keys(obj);
+  var hasAllKeys = true;
+  var missing = {};
+  keys.forEach(function(key) {
+    if (list.indexOf(key) === -1) {
+      hasAllKeys = false;
+      missing[key] = true;
+    }
+  });
+  return {hasAllKeys: hasAllKeys, missing: missing};
 };
 
 // used to mark the orderings and count of incoming rippled
@@ -32,27 +32,27 @@ function OrderList(list) {
     var idx = 0;
     this.isMock = true;
     this.create = function(__list) {
-        _list = __list;
-        idx = 0;
+      _list = __list;
+      idx = 0;
     };
     this.mark = function(command) {
-        if ((_list[idx]) && (_list[idx].command === command)) {
-            idx++;
-        } else {
-            throw new Error('out of order rippled command', command);
-        }
+      if ((_list[idx]) && (_list[idx].command === command)) {
+        idx++;
+      } else {
+        throw new Error('out of order rippled command', command);
+      }
     };
     this.test = function() {
-        if (this.isMock) {
-          return idx === _list.length;
-        }
-        return true;
+      if (this.isMock) {
+        return idx === _list.length;
+      }
+      return true;
     };
     this.reset = function() {
-        _list = [];
-        idx = 0;
+      _list = [];
+      idx = 0;
     };
-}
+  }
 
 var orderlist = new OrderList();
 
@@ -200,7 +200,7 @@ suite('payments', function() {
       });
 
       orderlist.mark('submit');
-     }
+    }
 
     orderlist.create([
       {command: 'subscribe'},
@@ -235,24 +235,24 @@ suite('payments', function() {
     ]);
 
     function _account_info(data) {
-        delete data.id;
-        assert.deepEqual(data, {
-          command: 'account_info',
-          account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
-          ledger_index: 'validated'
-        });
-        orderlist.mark('account_info');
+      delete data.id;
+      assert.deepEqual(data, {
+        command: 'account_info',
+        account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
+        ledger_index: 'validated'
+      });
+      orderlist.mark('account_info');
     }
 
     function _account_lines(data) {
-        delete data.id;
-        assert.deepEqual(data, {
-          command: 'account_lines',
-          account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
-          ledger_index: 'validated',
-          limit: 200
-        });
-        orderlist.mark('account_lines');
+      delete data.id;
+      assert.deepEqual(data, {
+        command: 'account_lines',
+        account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U',
+        ledger_index: 'validated',
+        limit: 200
+      });
+      orderlist.mark('account_lines');
     }
 
     route.once('account_info', _account_info);
@@ -291,12 +291,12 @@ suite('payments', function() {
     }
 
     function _account_info(data) {
-        orderlist.mark('account_info');
-        delete data.id;
-        assert.deepEqual(data, {
-          command: 'account_info',
-          account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U'
-        });
+      orderlist.mark('account_info');
+      delete data.id;
+      assert.deepEqual(data, {
+        command: 'account_info',
+        account: 'rJRLoJSErtNRFnbCyHEUYnRUKNwkVYDM7U'
+      });
     }
 
     route.once('ripple_path_find', _ripple_path_find);

--- a/test/fixtures/payments.js
+++ b/test/fixtures/payments.js
@@ -483,14 +483,14 @@ module.exports.RESTTransactionResponse = function(options) {
       source_amount: {
         value: '1.112209',
         currency: 'XRP',
-        counterparty: ''
+        issuer: ''
       },
       source_slippage: '0',
       destination_account: options.toAccount,
       destination_tag: '',
       destination_amount: {
         currency: 'USD',
-        counterparty: options.toAccount,
+        issuer: options.toAccount,
         value: '0.001'
       },
       invoice_id: '',
@@ -505,29 +505,29 @@ module.exports.RESTTransactionResponse = function(options) {
         {
           currency: 'XRP',
           value: '-1.101208',
-          counterparty: ''
+          issuer: ''
         }
       ],
       source_balance_changes: [
         {
           value: '-1.101208',
           currency: 'XRP',
-          counterparty: ''
+          issuer: ''
         }
       ],
       destination_balance_changes: [
         {
           value: '0.001',
           currency: 'USD',
-          counterparty: addresses.COUNTERPARTY
+          issuer: addresses.COUNTERPARTY
         }
       ],
       order_changes: [
         {
-          taker_pays: { currency: 'XRP', counterparty: '', value: '-1.101198' },
+          taker_pays: { currency: 'XRP', issuer: '', value: '-1.101198' },
           taker_gets:
           { currency: 'USD',
-            counterparty: addresses.COUNTERPARTY,
+            issuer: addresses.COUNTERPARTY,
             value: '-0.001002' },
           sequence: 58,
             status: 'open' }
@@ -563,14 +563,14 @@ module.exports.RESTAccountTransactionsResponse = function(options) {
           source_amount: {
             value: '1.112209',
             currency: 'XRP',
-            counterparty: ''
+            issuer: ''
           },
           source_slippage: '0',
           destination_account: options.toAccount,
           destination_tag: '',
           destination_amount: {
             currency: 'USD',
-            counterparty: options.toAccount,
+            issuer: options.toAccount,
             value: '0.001'
           },
           invoice_id: '',
@@ -585,28 +585,28 @@ module.exports.RESTAccountTransactionsResponse = function(options) {
             {
               currency: 'XRP',
               value: '-1.101208',
-              counterparty: ''
+              issuer: ''
             }
           ],
           source_balance_changes: [
             {
               value: '-1.101208',
               currency: 'XRP',
-              counterparty: ''
+              issuer: ''
             }
           ],
           destination_balance_changes: [
             {
               value: '0.001',
               currency: 'USD',
-              counterparty: addresses.COUNTERPARTY
+              issuer: addresses.COUNTERPARTY
             }
           ],
           order_changes: [
-            { taker_pays: { currency: 'XRP', counterparty: '', value: '-1.101198' },
+            { taker_pays: { currency: 'XRP', issuer: '', value: '-1.101198' },
               taker_gets:
               { currency: 'USD',
-                counterparty: addresses.COUNTERPARTY,
+                issuer: addresses.COUNTERPARTY,
                 value: '-0.001002' },
               sequence: 58,
               status: 'open'
@@ -639,7 +639,7 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
       source_tag: '',
       source_amount: {
         currency: '0158415500000000C1F76FF6ECB0BAC600000000',
-        counterparty: addresses.COUNTERPARTY,
+        issuer: addresses.COUNTERPARTY,
         value: '0.00000001'
       },
       source_slippage: '0',
@@ -647,7 +647,7 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
       destination_tag: '',
       destination_amount: {
         currency: '0158415500000000C1F76FF6ECB0BAC600000000',
-        counterparty: addresses.COUNTERPARTY,
+        issuer: addresses.COUNTERPARTY,
         value: '0.00000001'
       },
       invoice_id: '',
@@ -662,31 +662,31 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
         {
           currency: 'XRP',
           value: '-0.012',
-          counterparty: ''
+          issuer: ''
         },
         {
           currency: '0158415500000000C1F76FF6ECB0BAC600000000',
           value: '-1e-8',
-          counterparty: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
+          issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
         }
       ],
       source_balance_changes: [
         {
           value: '-0.012',
           currency: 'XRP',
-          counterparty: ''
+          issuer: ''
         },
         {
           value: '-1e-8',
           currency: '0158415500000000C1F76FF6ECB0BAC600000000',
-          counterparty: addresses.COUNTERPARTY
+          issuer: addresses.COUNTERPARTY
         }
       ],
       destination_balance_changes: [
         {
           value: '1e-8',
           currency: '0158415500000000C1F76FF6ECB0BAC600000000',
-          counterparty: addresses.VALID
+          issuer: addresses.VALID
         }
       ],
       order_changes: []
@@ -705,9 +705,9 @@ module.exports.payment = function(options) {
     clientResourceId: '1',
     value: '1',
     currency: 'XRP',
-    counterparty: '',
-    destinationAccount: addresses.COUNTERPARTY,
-    sourceAccount: addresses.VALID
+    issuer: '',
+    sourceAccount: addresses.VALID,
+    destinationAccount: addresses.COUNTERPARTY
   });
 
   return {
@@ -722,7 +722,7 @@ module.exports.payment = function(options) {
       destination_amount: {
         value: options.value,
         currency: options.currency,
-        counterparty: options.counterparty
+        issuer: options.issuer
       },
       memos: options.memos
     }

--- a/test/fixtures/payments.js
+++ b/test/fixtures/payments.js
@@ -1,11 +1,14 @@
+/* eslint-disable new-cap */
+/* eslint-disable valid-jsdoc */
+/* eslint-disable max-len */
+'use strict';
+
 var _ = require('lodash');
 var addresses = require('./../fixtures').addresses;
-var paths = require('./paths');
 var SerializedObject = require('ripple-lib').SerializedObject;
 
-var fromAccount   = addresses.VALID;
-var fromSecret    = addresses.SECRET;
-var toAccount     = addresses.COUNTERPARTY;
+var fromAccount = addresses.VALID;
+var toAccount = addresses.COUNTERPARTY;
 var issuerAccount = addresses.ISSUER;
 
 module.exports.VALID_TRANSACTION_HASH = '22F45FBD4DFDE03CF5AED05F3F858C06E9206D07098E469363F9D48D9D019589';
@@ -157,7 +160,7 @@ var METADATA = module.exports.METADATA = {
   TransactionResult: 'tesSUCCESS'
 };
 
-module.exports.binaryTransactionSynth = function (options) {
+module.exports.binaryTransactionSynth = function(options) {
   return {
     date: 416447810,
     hash: options.hash,
@@ -167,7 +170,7 @@ module.exports.binaryTransactionSynth = function (options) {
   };
 };
 
-module.exports.binaryTransaction = function (options) {
+module.exports.binaryTransaction = function(options) {
   options = options || {};
   _.defaults(options, {
     memos: []
@@ -199,18 +202,18 @@ module.exports.binaryTransaction = function (options) {
           type: 49,
           type_hex: '0000000000000031'
         }
-      ] 
+      ]
     ],
     SendMax: '1112209',
     Sequence: 4,
     SigningPubKey: '02BC8C02199949B15C005B997E7C8594574E9B02BA2D0628902E0532989976CF9D',
     TransactionType: 'Payment',
-    TxnSignature: '304502204EE3E9D1B01D8959B08450FCA9E22025AF503DEF310E34A93863A85CAB3C0BC5022100B61F5B567F77026E8DEED89EED0B7CAF0E6C96C228A2A65216F0DC2D04D52083',
+    TxnSignature: '304502204EE3E9D1B01D8959B08450FCA9E22025AF503DEF310E34A93863A85CAB3C0BC5022100B61F5B567F77026E8DEED89EED0B7CAF0E6C96C228A2A65216F0DC2D04D52083'
   };
 };
 
 module.exports.requestPath = function(address, params) {
-  return '/v1/accounts/' + address + '/payments' + ( params || '' );
+  return '/v1/accounts/' + address + '/payments' + (params || '');
 };
 
 module.exports.accountTransactionsResponse = function(request, options) {
@@ -246,7 +249,7 @@ module.exports.accountTransactionsResponse = function(request, options) {
           type: 49,
           type_hex: '0000000000000031'
         }
-      ] 
+      ]
     ],
     SendMax: '1112209',
     Sequence: 4,
@@ -494,7 +497,7 @@ module.exports.RESTTransactionResponse = function(options) {
         value: '0.001'
       },
       invoice_id: '',
-      paths: '[[{"currency":"USD","issuer":"' + addresses.COUNTERPARTY + '","type":48,"type_hex":"0000000000000030"},{"account":"' + addresses.COUNTERPARTY + '","currency":"USD","issuer":"' + addresses.COUNTERPARTY + '","type":49,"type_hex":"0000000000000031"}]]',
+      paths: '[[{\"currency\":\"USD\",\"issuer\":\"' + addresses.COUNTERPARTY + '\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"' + addresses.COUNTERPARTY + '\",\"currency\":\"USD\",\"issuer\":\"' + addresses.COUNTERPARTY + '\",\"type\":49,\"type_hex\":\"0000000000000031\"}]]',
       no_direct_ripple: false,
       partial_payment: false,
       direction: 'outgoing',
@@ -524,13 +527,13 @@ module.exports.RESTTransactionResponse = function(options) {
       ],
       order_changes: [
         {
-          taker_pays: { currency: 'XRP', issuer: '', value: '-1.101198' },
+          taker_pays: {currency: 'XRP', issuer: '', value: '-1.101198'},
           taker_gets:
-          { currency: 'USD',
+          {currency: 'USD',
             issuer: addresses.COUNTERPARTY,
-            value: '-0.001002' },
+            value: '-0.001002'},
           sequence: 58,
-            status: 'open' }
+            status: 'open'}
         ],
       memos: options.memos
     },
@@ -603,11 +606,11 @@ module.exports.RESTAccountTransactionsResponse = function(options) {
             }
           ],
           order_changes: [
-            { taker_pays: { currency: 'XRP', issuer: '', value: '-1.101198' },
+            {taker_pays: {currency: 'XRP', issuer: '', value: '-1.101198'},
               taker_gets:
-              { currency: 'USD',
+              {currency: 'USD',
                 issuer: addresses.COUNTERPARTY,
-                value: '-0.001002' },
+                value: '-0.001002'},
               sequence: 58,
               status: 'open'
             }
@@ -694,7 +697,7 @@ module.exports.RESTTransactionResponseComplexCurrencies = function(options) {
     client_resource_id: options.client_resource_id,
     hash: options.hash,
     ledger: options.ledger,
-    state: 'validated',
+    state: 'validated'
   });
 };
 
@@ -906,7 +909,7 @@ module.exports.rippledSubmitErrorResponse = function(request, options) {
   );
 };
 
-module.exports.rippledSubscribeRequest = function(request, lastLedger) {
+module.exports.rippledSubscribeRequest = function(request) {
   return JSON.stringify({
     id: request.id,
     command: 'subscribe',
@@ -1410,7 +1413,7 @@ module.exports.verifiedResponseComplexCurrency = function(options) {
     type: 'transaction',
     validated: true
   });
-}
+};
 
 module.exports.ledgerSequenceTooHighResponse = function(request) {
   return JSON.stringify(
@@ -1462,7 +1465,8 @@ module.exports.RESTSuccessResponse = function(options) {
     {
       success: true,
       client_resource_id: options.clientResourceId,
-      status_url: 'http://127.0.0.1:5990/v1/accounts/'+fromAccount+'/payments/'+options.clientResourceId
+      status_url: 'http://127.0.0.1:5990/v1/accounts/' + fromAccount +
+        '/payments/' + options.clientResourceId
     }
   );
 };

--- a/test/orders-test.js
+++ b/test/orders-test.js
@@ -1617,7 +1617,6 @@ suite('get order book', function() {
   });
 
   test('v1/accounts/:account/order_book/:base/:counter -- with XRP as base', function(done) {
-
     self.wss.on('request_ledger', function(message, conn) {
       assert.strictEqual(message.ledger_index, 'validated');
       conn.send(fixtures.requestLedgerResponse(message, {

--- a/test/orders-test.js
+++ b/test/orders-test.js
@@ -1,6 +1,7 @@
 /* eslint-disable new-cap */
 /* eslint-disable max-len */
 'use strict';
+
 var assert = require('assert');
 var ripple = require('ripple-lib');
 var testutils = require('./testutils');
@@ -341,7 +342,7 @@ suite('post orders', function() {
         hash: hash
       }));
 
-      process.nextTick(function () {
+      process.nextTick(function() {
         conn.send(fixtures.submitTransactionVerifiedResponse({
           hash: hash
         }));
@@ -462,7 +463,7 @@ suite('post orders', function() {
       conn.send(fixtures.accountInfoResponse(message));
     });
 
-    self.wss.once('request_submit', function (message, conn) {
+    self.wss.once('request_submit', function(message, conn) {
       var so = new ripple.SerializedObject(message.tx_blob).to_json();
       assert.strictEqual(so.TakerGets.value, VALUE);
       assert.strictEqual(so.TakerGets.currency, HEX_CURRENCY);
@@ -516,7 +517,7 @@ suite('post orders', function() {
       conn.send(fixtures.accountInfoResponse(message));
     });
 
-    self.wss.once('request_submit', function (message, conn) {
+    self.wss.once('request_submit', function(message, conn) {
       var so = new ripple.SerializedObject(message.tx_blob).to_json();
       assert.strictEqual(so.TakerPays.value, VALUE);
       assert.strictEqual(so.TakerPays.currency, HEX_CURRENCY);

--- a/test/paths-test.js
+++ b/test/paths-test.js
@@ -76,7 +76,7 @@ suite('get payment paths', function() {
     .expect(testutils.checkBody(errors.RESTErrorResponse({
       type: 'invalid_request',
       error: 'restINVALID_PARAMETER',
-      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+counterparty'
+      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+issuer'
     })))
     .end(done);
   });
@@ -97,12 +97,12 @@ suite('get payment paths', function() {
     .expect(testutils.checkBody(errors.RESTErrorResponse({
       type: 'invalid_request',
       error: 'restINVALID_PARAMETER',
-      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+counterparty'
+      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+issuer'
     })))
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- invalid destination currency counterparty', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- invalid destination currency issuer', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert(false);
     });
@@ -118,12 +118,12 @@ suite('get payment paths', function() {
     .expect(testutils.checkBody(errors.RESTErrorResponse({
       type: 'invalid_request',
       error: 'restINVALID_PARAMETER',
-      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+counterparty'
+      message: 'Invalid parameter: destination_amount. Must be an amount string in the form value+currency+issuer'
     })))
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- invalid IOU source currency without counterparty', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- invalid IOU source currency without issuer', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert(false);
     });
@@ -144,7 +144,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with invalid counterparty', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with invalid issuer', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert(false);
     });
@@ -165,7 +165,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with valid counterparty', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with valid issuer', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.VALID);
@@ -192,7 +192,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- multiple valid IOU source currencies with valid counterparty', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- multiple valid IOU source currencies with valid issuer', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.VALID);
@@ -244,7 +244,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- multiple source currencies with invalid last source currency counterparty', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- multiple source currencies with invalid last source currency issuer', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert(false);
     });
@@ -265,7 +265,7 @@ suite('get payment paths', function() {
     .end(done);
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- XRP source amount response has source account, destination account, and destination amount counterparty correctly set', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- XRP source amount response has source account, destination account, and destination amount issuer correctly set', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.VALID);
@@ -289,7 +289,7 @@ suite('get payment paths', function() {
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.source_account, addresses.VALID);
         assert.strictEqual(paymentObj.destination_account, addresses.VALID);
-        assert.strictEqual(paymentObj.destination_amount.counterparty, '');
+        assert.strictEqual(paymentObj.destination_amount.issuer, '');
       });
 
       done();
@@ -322,14 +322,14 @@ suite('get payment paths', function() {
         _.each(res.body.payments, function(paymentObj) {
           assert.strictEqual(paymentObj.source_account, addresses.VALID);
           assert.strictEqual(paymentObj.destination_account, addresses.VALID);
-          assert.strictEqual(paymentObj.destination_amount.counterparty, addresses.VALID);
+          assert.strictEqual(paymentObj.destination_amount.issuer, addresses.VALID);
         });
 
         done();
       });
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- IOU destination amount response has source amount counterparty set to alternative\'s source amount counterparty but defaults to source account for all non-XRP source amounts', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- IOU destination amount response has source amount issuer set to alternative\'s source amount issuer but defaults to source account for all non-XRP source amounts', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.COUNTERPARTY);
@@ -350,9 +350,9 @@ suite('get payment paths', function() {
     .end(function(err, res) {
       if (err) return done(err);
 
-      assert.strictEqual(res.body.payments[0].source_amount.counterparty, '');
-      assert.strictEqual(res.body.payments[1].source_amount.counterparty, addresses.VALID);
-      assert.strictEqual(res.body.payments[2].source_amount.counterparty, '');
+      assert.strictEqual(res.body.payments[0].source_amount.issuer, '');
+      assert.strictEqual(res.body.payments[1].source_amount.issuer, addresses.VALID);
+      assert.strictEqual(res.body.payments[2].source_amount.issuer, '');
 
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.source_account, addresses.COUNTERPARTY);
@@ -363,12 +363,14 @@ suite('get payment paths', function() {
     });
   });
 
-  test('/accounts/:account/payments/paths/:destination/:amount -- IOU destination amount has source account, destination account, and destination amount counterparty correctly set', function(done) {
+  test('/accounts/:account/payments/paths/:destination/:amount -- IOU destination amount has source account, destination account, and destination amount issuer correctly set', function(done) {
     self.wss.once('request_ripple_path_find', function(message, conn) {
       assert.strictEqual(message.command, 'ripple_path_find');
       assert.strictEqual(message.source_account, addresses.VALID);
       assert.strictEqual(message.destination_account, addresses.VALID);
-      conn.send(pathFixtures.generateIOUPaymentPaths(message.id, message.source_account, message.destination_account, message.destination_amount));
+      conn.send(pathFixtures.generateIOUPaymentPaths(
+        message.id, message.source_account, message.destination_account,
+        message.destination_amount));
     });
 
     self.app
@@ -381,7 +383,7 @@ suite('get payment paths', function() {
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.source_account, addresses.VALID);
         assert.strictEqual(paymentObj.destination_account, addresses.VALID);
-        assert.strictEqual(paymentObj.destination_amount.counterparty, addresses.ISSUER);
+        assert.strictEqual(paymentObj.destination_amount.issuer, addresses.ISSUER);
       });
 
       done();
@@ -404,7 +406,7 @@ suite('get payment paths', function() {
       if (err) return done(err);
 
       _.each(res.body.payments, function(paymentObj) {
-        assert.strictEqual(paymentObj.destination_amount.counterparty, addresses.VALID);
+        assert.strictEqual(paymentObj.destination_amount.issuer, addresses.VALID);
       });
 
       done();

--- a/test/paths-test.js
+++ b/test/paths-test.js
@@ -1,29 +1,30 @@
+/* eslint-disable new-cap */
+/* eslint-disable max-len */
+'use strict';
+
 var assert = require('assert');
-var ripple = require('ripple-lib');
 var _ = require('lodash');
 var testutils = require('./testutils');
 var fixtures = require('./fixtures').payments;
 var pathFixtures = require('./fixtures').paths;
 var errors = require('./fixtures').errors;
 var addresses = require('./fixtures').addresses;
-var requestPath = fixtures.requestPath;
-var Payments = require('./../api/payments');
 
 suite('get payment paths', function() {
   var self = this;
 
-  //self.wss: rippled mock
-  //self.app: supertest-enabled REST handler
+  // self.wss: rippled mock
+  // self.app: supertest-enabled REST handler
 
   setup(testutils.setup.bind(self));
   teardown(testutils.teardown.bind(self));
 
   test('/accounts/:account/payments/paths/:destination/:amount -- invalid source account', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -40,11 +41,11 @@ suite('get payment paths', function() {
   });
 
   test('/accounts/:account/payments/paths/:destination/:amount -- invalid destination account', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -61,11 +62,11 @@ suite('get payment paths', function() {
   });
 
   test('/accounts/:account/payments/paths/:destination/:amount -- missing destination currency', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -82,11 +83,11 @@ suite('get payment paths', function() {
   });
 
   test('/accounts/:account/payments/paths/:destination/:amount -- invalid destination currency format', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -103,11 +104,11 @@ suite('get payment paths', function() {
   });
 
   test('/accounts/:account/payments/paths/:destination/:amount -- invalid destination currency issuer', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -124,11 +125,11 @@ suite('get payment paths', function() {
   });
 
   test('/accounts/:account/payments/paths/:destination/:amount -- invalid IOU source currency without issuer', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -145,11 +146,11 @@ suite('get payment paths', function() {
   });
 
   test('/accounts/:account/payments/paths/:destination/:amount -- valid IOU source currency with invalid issuer', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -171,10 +172,10 @@ suite('get payment paths', function() {
       assert.strictEqual(message.source_account, addresses.VALID);
       assert.strictEqual(message.destination_account, addresses.VALID);
       assert.strictEqual(message.source_currencies.length, 1);
-      assert.deepEqual(message.source_currencies[0], { 
+      assert.deepEqual(message.source_currencies[0], {
         issuer: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
-        currency: '0000000000000000000000005553440000000000' 
-      })
+        currency: '0000000000000000000000005553440000000000'
+      });
 
       conn.send(pathFixtures.generateXRPPaymentPaths(message.id, message.source_account, message.destination_account, message.destination_amount));
     });
@@ -198,13 +199,13 @@ suite('get payment paths', function() {
       assert.strictEqual(message.source_account, addresses.VALID);
       assert.strictEqual(message.destination_account, addresses.VALID);
       assert.strictEqual(message.source_currencies.length, 2);
-      assert.deepEqual(message.source_currencies[0], { 
+      assert.deepEqual(message.source_currencies[0], {
         issuer: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
-        currency: '0000000000000000000000005553440000000000' 
+        currency: '0000000000000000000000005553440000000000'
       });
-      assert.deepEqual(message.source_currencies[1], { 
+      assert.deepEqual(message.source_currencies[1], {
         issuer: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
-        currency: '0000000000000000000000004944520000000000' 
+        currency: '0000000000000000000000004944520000000000'
       });
 
       conn.send(pathFixtures.generateXRPPaymentPaths(message.id, message.source_account, message.destination_account, message.destination_amount));
@@ -224,11 +225,11 @@ suite('get payment paths', function() {
   });
 
   test('/accounts/:account/payments/paths/:destination/:amount -- mutliple source currencies with invalid last source currency', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -245,11 +246,11 @@ suite('get payment paths', function() {
   });
 
   test('/accounts/:account/payments/paths/:destination/:amount -- multiple source currencies with invalid last source currency issuer', function(done) {
-    self.wss.once('request_ripple_path_find', function(message, conn) {
+    self.wss.once('request_ripple_path_find', function() {
       assert(false);
     });
 
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
@@ -284,7 +285,9 @@ suite('get payment paths', function() {
     .expect(testutils.checkStatus(200))
     .expect(testutils.checkHeaders)
     .end(function(err, res) {
-      if (err) return done(err);
+      if (err) {
+        return done(err);
+      }
 
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.source_account, addresses.VALID);
@@ -317,7 +320,9 @@ suite('get payment paths', function() {
       .expect(testutils.checkStatus(200))
       .expect(testutils.checkHeaders)
       .end(function(err, res) {
-        if (err) return done(err);
+        if (err) {
+          return done(err);
+        }
 
         _.each(res.body.payments, function(paymentObj) {
           assert.strictEqual(paymentObj.source_account, addresses.VALID);
@@ -348,7 +353,9 @@ suite('get payment paths', function() {
     .expect(testutils.checkStatus(200))
     .expect(testutils.checkHeaders)
     .end(function(err, res) {
-      if (err) return done(err);
+      if (err) {
+        return done(err);
+      }
 
       assert.strictEqual(res.body.payments[0].source_amount.issuer, '');
       assert.strictEqual(res.body.payments[1].source_amount.issuer, addresses.VALID);
@@ -378,7 +385,9 @@ suite('get payment paths', function() {
     .expect(testutils.checkStatus(200))
     .expect(testutils.checkHeaders)
     .end(function(err, res) {
-      if (err) return done(err);
+      if (err) {
+        return done(err);
+      }
 
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.source_account, addresses.VALID);
@@ -403,7 +412,9 @@ suite('get payment paths', function() {
     .expect(testutils.checkStatus(200))
     .expect(testutils.checkHeaders)
     .end(function(err, res) {
-      if (err) return done(err);
+      if (err) {
+        return done(err);
+      }
 
       _.each(res.body.payments, function(paymentObj) {
         assert.strictEqual(paymentObj.destination_amount.issuer, addresses.VALID);

--- a/test/payments-test.js
+++ b/test/payments-test.js
@@ -138,7 +138,7 @@ suite('post payments', function() {
   setup(testutils.setup.bind(self));
   teardown(testutils.teardown.bind(self));
 
-  test('/payments -- counterparty', function(done){
+  test('/payments -- issuer', function(done){
     var hash = testutils.generateHash();
 
     self.wss.once('request_account_info', function(message, conn) {
@@ -157,7 +157,7 @@ suite('post payments', function() {
       .send(fixtures.payment({
         value: '0.001',
         currency: 'USD',
-        counterparty: addresses.ISSUER,
+        issuer: addresses.ISSUER,
         hash: hash
       }))
       .expect(testutils.checkStatus(200))
@@ -166,7 +166,7 @@ suite('post payments', function() {
       .end(done);
   });
 
-  test('/payments -- no counterparty', function(done){
+  test('/payments -- no issuer', function(done){
     var hash = testutils.generateHash();
 
     self.wss.once('request_account_info', function(message, conn) {
@@ -247,7 +247,7 @@ suite('post payments', function() {
       .send(fixtures.payment({
         value: '0.0001',
         currency: '015841550000000041F78E0A28CBF19200000000',
-        counterparty: addresses.VALID,
+        issuer: addresses.VALID,
         hash: hash
       }))
       .expect(testutils.checkStatus(200))
@@ -363,7 +363,7 @@ suite('post payments', function() {
       .send(fixtures.payment({
         value: '0.0001',
         currency: '015841550000000041F78E0A28CBF19200000000',
-        counterparty: addresses.VALID,
+        issuer: addresses.VALID,
         hash: hash
       }))
       .expect(testutils.checkStatus(200))
@@ -441,7 +441,7 @@ suite('post payments', function() {
     .send(fixtures.payment({
       value: '0.001',
       currency: 'USD',
-      counterparty: addresses.ISSUER,
+      issuer: addresses.ISSUER,
       max_fee: utils.dropsToXrp(10)
     }))
     .expect(testutils.checkBody(errors.RESTMaxFeeExceeded))
@@ -490,7 +490,7 @@ suite('post payments', function() {
     .send(fixtures.payment({
       value: '0.001',
       currency: 'USD',
-      counterparty: addresses.ISSUER,
+      issuer: addresses.ISSUER,
       max_fee: 0.000010
     }))
     .expect(testutils.checkStatus(500))
@@ -720,7 +720,7 @@ suite('post payments', function() {
     .send(fixtures.payment({
       value: '0.001',
       currency: 'USD',
-      counterparty: addresses.issuer,
+      issuer: addresses.issuer,
       lastLedgerSequence: 9036185
     }))
     .expect(testutils.checkStatus(200))
@@ -756,7 +756,7 @@ suite('post payments', function() {
     .send(fixtures.payment({
       value: '0.001',
       currency: 'USD',
-      counterparty: addresses.ISSUER,
+      issuer: addresses.ISSUER,
       max_fee: 0.000015
     }))
     .expect(testutils.checkBody(errors.RESTResponseLedgerSequenceTooHigh))
@@ -781,7 +781,7 @@ suite('post payments', function() {
     .send(fixtures.payment({
       value: '0.001',
       currency: 'USD',
-      counterparty: addresses.ISSUER,
+      issuer: addresses.ISSUER,
       max_fee: 0.000010
     }))
     .expect(testutils.checkStatus(500))
@@ -809,7 +809,7 @@ suite('post payments', function() {
     .send(fixtures.payment({
       value: '0.001',
       currency: 'USD',
-      counterparty: addresses.ISSUER,
+      issuer: addresses.ISSUER,
       max_fee: 0.001200
     }))
     .expect(testutils.checkStatus(200))
@@ -1224,7 +1224,7 @@ suite('post payments', function() {
       .send(fixtures.payment({
         value: '0.001',
         currency: 'USD',
-        counterparty: addresses.ISSUER,
+        issuer: addresses.ISSUER,
         hash: hash,
         clientResourceId: ''
       }))
@@ -1257,7 +1257,7 @@ suite('post payments', function() {
       .send(fixtures.payment({
         value: '0.001',
         currency: 'USD',
-        counterparty: addresses.ISSUER,
+        issuer: addresses.ISSUER,
         hash: hash,
         clientResourceId: testutils.generateHash()
       }))
@@ -1290,7 +1290,7 @@ suite('post payments', function() {
       .send(fixtures.payment({
         value: '0.001',
         currency: 'USD',
-        counterparty: addresses.ISSUER,
+        issuer: addresses.ISSUER,
         hash: hash,
         sourceAccount: 'foo'
       }))
@@ -1323,7 +1323,7 @@ suite('post payments', function() {
       .send(fixtures.payment({
         value: '0.001',
         currency: 'USD',
-        counterparty: addresses.ISSUER,
+        issuer: addresses.ISSUER,
         hash: hash,
         destinationAccount: 'foo'
       }))
@@ -1337,13 +1337,13 @@ suite('post payments', function() {
       .end(done);
   });
 
-  test.skip('/payments -- counterparty with XRP source_amount', function(done) {
+  test.skip('/payments -- issuer with XRP source_amount', function(done) {
   });
 
-  test.skip('/payments -- counterparty with XRP destination_amount', function(done) {
+  test.skip('/payments -- issuer with XRP destination_amount', function(done) {
   });
 
-  test.skip('/payments -- counterparty with XRP destination_amount', function(done) {
+  test.skip('/payments -- issuer with XRP destination_amount', function(done) {
   });
 
   test.skip('/payments -- valid source_tag', function(done) {

--- a/test/payments-test.js
+++ b/test/payments-test.js
@@ -1,18 +1,20 @@
-var _           = require('lodash');
-var assert      = require('assert-diff');
-var ripple      = require('ripple-lib');
-var testutils   = require('./testutils');
-var fixtures    = require('./fixtures').payments;
-var errors      = require('./fixtures').errors;
-var addresses   = require('./fixtures').addresses;
-var utils       = require('../api/lib/utils');
+/* eslint-disable new-cap */
+/* eslint-disable max-len */
+'use strict';
+var assert = require('assert-diff');
+var ripple = require('ripple-lib');
+var testutils = require('./testutils');
+var fixtures = require('./fixtures').payments;
+var errors = require('./fixtures').errors;
+var addresses = require('./fixtures').addresses;
+var utils = require('../api/lib/utils');
 var requestPath = fixtures.requestPath;
 
 suite('get payments', function() {
   var self = this;
 
-  //self.wss: rippled mock
-  //self.app: supertest-enabled REST handler
+  // self.wss: rippled mock
+  // self.app: supertest-enabled REST handler
 
   setup(testutils.setup.bind(self));
   teardown(testutils.teardown.bind(self));
@@ -36,8 +38,7 @@ suite('get payments', function() {
     .end(done);
   });
 
-  test.skip('/accounts/:account/payments/:identifier -- with identifier as client_resource_id', function(done) {
-  });
+  test('/accounts/:account/payments/:identifier -- with identifier as client_resource_id');
 
   test('/accounts/:account/payments/:identifier -- with identifier as txn hash', function(done) {
     self.wss.once('request_tx', function(message, conn) {
@@ -99,7 +100,7 @@ suite('get payments', function() {
   });
 
   test('/accounts/:account/payments/:identifier -- invalid identifier', function(done) {
-    self.wss.once('request_tx', function(message, conn) {
+    self.wss.once('request_tx', function() {
       assert(false, 'Should not request transaction');
     });
 
@@ -116,7 +117,7 @@ suite('get payments', function() {
   });
 
   test('/accounts/:account/payments/:identifier -- invalid account', function(done) {
-    self.wss.once('request_tx', function(message, conn) {
+    self.wss.once('request_tx', function() {
       assert(false, 'Should not request transaction');
     });
 
@@ -132,13 +133,13 @@ suite('get payments', function() {
 suite('post payments', function() {
   var self = this;
 
-  //self.wss: rippled mock
-  //self.app: supertest-enabled REST handler
+  // self.wss: rippled mock
+  // self.app: supertest-enabled REST handler
 
   setup(testutils.setup.bind(self));
   teardown(testutils.teardown.bind(self));
 
-  test('/payments -- issuer', function(done){
+  test('/payments -- issuer', function(done) {
     var hash = testutils.generateHash();
 
     self.wss.once('request_account_info', function(message, conn) {
@@ -166,7 +167,7 @@ suite('post payments', function() {
       .end(done);
   });
 
-  test('/payments -- no issuer', function(done){
+  test('/payments -- no issuer', function(done) {
     var hash = testutils.generateHash();
 
     self.wss.once('request_account_info', function(message, conn) {
@@ -228,7 +229,7 @@ suite('post payments', function() {
       .end(done);
   });
 
-  test('/payments -- hex currency gold', function(done){
+  test('/payments -- hex currency gold', function(done) {
     var hash = testutils.generateHash();
 
     self.wss.once('request_account_info', function(message, conn) {
@@ -256,7 +257,7 @@ suite('post payments', function() {
       .end(done);
   });
 
-  test('/payments?validated=true', function(done){
+  test('/payments?validated=true', function(done) {
     var currentLedger = self.remote._ledger_current_index;
 
     self.wss.once('request_account_info', function(message, conn) {
@@ -269,7 +270,7 @@ suite('post payments', function() {
       assert.strictEqual(message.command, 'submit');
       conn.send(fixtures.requestSubmitResponse(message));
 
-      process.nextTick(function () {
+      process.nextTick(function() {
         conn.send(fixtures.transactionVerifiedResponse({
           ledger: currentLedger
         }));
@@ -284,7 +285,7 @@ suite('post payments', function() {
     }))
     .expect(testutils.checkStatus(200))
     .expect(testutils.checkHeaders)
-    .expect(testutils.checkBody(fixtures.RESTTransactionResponse({ 
+    .expect(testutils.checkBody(fixtures.RESTTransactionResponse({
       hash: fixtures.VALID_SUBMITTED_TRANSACTION_HASH,
       ledger: currentLedger
     })))
@@ -310,7 +311,7 @@ suite('post payments', function() {
         fee: '5000000'
       }));
 
-      process.nextTick(function () {
+      process.nextTick(function() {
         conn.send(fixtures.transactionVerifiedResponse({
           hash: hash,
           fee: '5000000',
@@ -328,7 +329,7 @@ suite('post payments', function() {
       }))
       .expect(testutils.checkStatus(200))
       .expect(testutils.checkHeaders)
-      .expect(testutils.checkBody(fixtures.RESTTransactionResponse({ 
+      .expect(testutils.checkBody(fixtures.RESTTransactionResponse({
         hash: hash,
         fee: '5',
         ledger: currentLedger
@@ -336,7 +337,7 @@ suite('post payments', function() {
       .end(done);
   });
 
-  test('/payments?validated=true -- hex currency gold', function(done){
+  test('/payments?validated=true -- hex currency gold', function(done) {
     var hash = testutils.generateHash();
     var currentLedger = self.remote._ledger_current_index;
 
@@ -350,7 +351,7 @@ suite('post payments', function() {
       assert.strictEqual(message.command, 'submit');
       conn.send(fixtures.requestSubmitResponse(message, {hash: hash}));
 
-      process.nextTick(function () {
+      process.nextTick(function() {
         conn.send(fixtures.verifiedResponseComplexCurrency({
           hash: hash,
           ledger: currentLedger
@@ -432,7 +433,7 @@ suite('post payments', function() {
       conn.send(fixtures.accountInfoResponse(message));
     });
 
-    self.wss.once('request_submit', function(message, conn) {
+    self.wss.once('request_submit', function() {
       assert(false);
     });
 
@@ -481,7 +482,7 @@ suite('post payments', function() {
       conn.send(fixtures.accountInfoResponse(message));
     });
 
-    self.wss.once('request_submit', function(message, conn) {
+    self.wss.once('request_submit', function() {
       assert(false);
     });
 
@@ -682,11 +683,11 @@ suite('post payments', function() {
   });
 
   test('/payments -- secret invalid', function(done) {
-    self.wss.once('request_account_info', function(message, conn) {
+    self.wss.once('request_account_info', function() {
       assert(false);
     });
 
-    self.wss.once('request_submit', function(message, conn) {
+    self.wss.once('request_submit', function() {
       assert(false);
     });
 
@@ -712,7 +713,7 @@ suite('post payments', function() {
       var so = new ripple.SerializedObject(message.tx_blob).to_json();
       assert.strictEqual(message.command, 'submit');
       assert.strictEqual(so.LastLedgerSequence, 9036185);
-      conn.send(fixtures.requestSubmitResponse(message, { LastLedgerSequence: 9036185 }));
+      conn.send(fixtures.requestSubmitResponse(message, {LastLedgerSequence: 9036185}));
     });
 
     self.app
@@ -772,7 +773,7 @@ suite('post payments', function() {
       conn.send(fixtures.accountInfoResponse(message));
     });
 
-    self.wss.once('request_submit', function(message, conn) {
+    self.wss.once('request_submit', function() {
       assert(false);
     });
 
@@ -801,7 +802,7 @@ suite('post payments', function() {
       var so = new ripple.SerializedObject(message.tx_blob).to_json();
       assert.strictEqual(message.command, 'submit');
       assert.strictEqual(so.Fee, '12');
-      conn.send(fixtures.requestSubmitResponse(message, { Fee: '12' }));
+      conn.send(fixtures.requestSubmitResponse(message, {Fee: '12'}));
     });
 
     self.app
@@ -844,7 +845,7 @@ suite('post payments', function() {
         hash: hash
       }));
 
-      process.nextTick(function () {
+      process.nextTick(function() {
         conn.send(fixtures.rippledValidatedErrorResponse(message, {
           engineResult: 'tecNO_DST_INSUF_XRP',
           engineResultCode: '125',
@@ -883,7 +884,6 @@ suite('post payments', function() {
     });
 
     self.wss.once('request_submit', function(message, conn) {
-      var so = new ripple.SerializedObject(message.tx_blob).to_json();
       assert.strictEqual(message.command, 'submit');
       conn.send(fixtures.rippledSubmitErrorResponse(message, {
         engineResult: 'terINSUF_FEE_B',
@@ -956,13 +956,13 @@ suite('post payments', function() {
       assert.strictEqual(message.command, 'submit');
       conn.send(fixtures.requestSubmitResponse(message));
 
-      self.wss.once('request_submit', function(message, conn) {
+      self.wss.once('request_submit', function() {
         // second payment should not hit submit
         assert(false);
       });
     });
 
-    var secondPayment = function(err) {
+    function secondPayment(err) {
       if (err) {
         assert(false);
         return done(err);
@@ -981,7 +981,7 @@ suite('post payments', function() {
           message: 'Duplicate Transaction. A record already exists in the database for a transaction of this type with the same client_resource_id. If this was not an accidental resubmission please submit the transaction again with a unique client_resource_id'
         })))
         .end(done);
-    };
+    }
 
     self.app
       .post('/v1/accounts/' + addresses.VALID + '/payments')
@@ -1015,13 +1015,13 @@ suite('post payments', function() {
         hash: hash
       }));
 
-      self.wss.once('request_submit', function(message, conn) {
+      self.wss.once('request_submit', function() {
         // second payment should not hit submit
         assert(false);
       });
     });
 
-    var secondPayment = function(err) {
+    function secondPayment(err) {
       if (err) {
         assert(false);
         return done(err);
@@ -1040,7 +1040,7 @@ suite('post payments', function() {
           message: 'Duplicate Transaction. A record already exists in the database for a transaction of this type with the same client_resource_id. If this was not an accidental resubmission please submit the transaction again with a unique client_resource_id'
         })))
         .end(done);
-    };
+    }
 
     self.app
       .post('/v1/accounts/' + addresses.VALID + '/payments')
@@ -1079,7 +1079,7 @@ suite('post payments', function() {
         hash: hash
       }));
 
-      process.nextTick(function () {
+      process.nextTick(function() {
         conn.send(fixtures.rippledValidatedErrorResponse(message, {
           engineResult: 'tecNO_DST_INSUF_XRP',
           engineResultCode: '125',
@@ -1088,13 +1088,13 @@ suite('post payments', function() {
         }));
       });
 
-      self.wss.once('request_submit', function(message, conn) {
+      self.wss.once('request_submit', function() {
         // second payment should not hit submit
         assert(false);
       });
     });
 
-    var secondPayment = function(err) {
+    function secondPayment(err) {
       if (err) {
         assert(false);
         return done(err);
@@ -1113,7 +1113,7 @@ suite('post payments', function() {
           message: 'Duplicate Transaction. A record already exists in the database for a transaction of this type with the same client_resource_id. If this was not an accidental resubmission please submit the transaction again with a unique client_resource_id'
         })))
         .end(done);
-    };
+    }
 
     self.app
       .post('/v1/accounts/' + addresses.VALID + '/payments?validated=true')
@@ -1154,7 +1154,7 @@ suite('post payments', function() {
         hash: hash
       }));
 
-      process.nextTick(function () {
+      process.nextTick(function() {
         conn.send(fixtures.rippledValidatedErrorResponse(message, {
           engineResult: 'tecNO_DST_INSUF_XRP',
           engineResultCode: '125',
@@ -1163,13 +1163,13 @@ suite('post payments', function() {
         }));
       });
 
-      self.wss.once('request_submit', function(message, conn) {
+      self.wss.once('request_submit', function() {
         // second payment should not hit submit
         assert(false);
       });
     });
 
-    var secondPayment = function(err) {
+    function secondPayment(err) {
       if (err) {
         assert(false);
         return done(err);
@@ -1188,7 +1188,7 @@ suite('post payments', function() {
           message: 'Duplicate Transaction. A record already exists in the database for a transaction of this type with the same client_resource_id. If this was not an accidental resubmission please submit the transaction again with a unique client_resource_id'
         })))
         .end(done);
-    };
+    }
 
     self.app
       .post('/v1/accounts/' + addresses.VALID + '/payments?validated=true')
@@ -1337,46 +1337,32 @@ suite('post payments', function() {
       .end(done);
   });
 
-  test.skip('/payments -- issuer with XRP source_amount', function(done) {
-  });
+  test('/payments -- issuer with XRP source_amount');
 
-  test.skip('/payments -- issuer with XRP destination_amount', function(done) {
-  });
+  test('/payments -- issuer with XRP destination_amount');
 
-  test.skip('/payments -- issuer with XRP destination_amount', function(done) {
-  });
+  test('/payments -- issuer with XRP destination_amount');
 
-  test.skip('/payments -- valid source_tag', function(done) {
-  });
+  test('/payments -- valid source_tag');
 
-  test.skip('/payments -- invalid source_tag', function(done) {
-  });
+  test('/payments -- invalid source_tag');
 
-  test.skip('/payments -- valid destination_tag', function(done) {
-  });
+  test('/payments -- valid destination_tag');
 
-  test.skip('/payments -- invalid destination_tag', function(done) {
-  });
+  test('/payments -- invalid destination_tag');
 
-  test.skip('/payments -- invalid source_slippage', function(done) {
-  });
+  test('/payments -- invalid source_slippage');
 
-  test.skip('/payments -- invalid invoice_id', function(done) {
-  });
+  test('/payments -- invalid invoice_id');
 
-  test.skip('/payments -- invalid invoice_id', function(done) {
-  });
+  test('/payments -- invalid invoice_id');
 
-  test.skip('/payments -- invalid paths (object)', function(done) {
-  });
+  test('/payments -- invalid paths (object)');
 
-  test.skip('/payments -- invalid paths (string)', function(done) {
-  });
+  test('/payments -- invalid paths (string)');
 
-  test.skip('/payments -- invalid partial_payment flag', function(done) {
-  });
+  test('/payments -- invalid partial_payment flag');
 
-  test.skip('/payments -- invalid no_direct_ripple flag', function(done) {
-  });
+  test('/payments -- invalid no_direct_ripple flag');
 
 });

--- a/test/unit/fixtures/rest-converter.js
+++ b/test/unit/fixtures/rest-converter.js
@@ -9,7 +9,7 @@ module.exports.paymentRest = {
   'destination_amount': {
     'value': '0.001',
     'currency': 'USD',
-    'counterparty': addresses.COUNTERPARTY
+    'issuer': addresses.COUNTERPARTY
   }
 };
 
@@ -19,7 +19,7 @@ module.exports.paymentRestXRP = {
   'destination_amount': {
     'value': '1',
     'currency': 'XRP',
-    'counterparty': ''
+    'issuer': ''
   }
 };
 
@@ -29,7 +29,7 @@ module.exports.paymentRestComplex = {
   'source_amount': {
     'value': '10',
     'currency': 'USD',
-    'counterparty': addresses.VALID
+    'issuer': addresses.VALID
   },
   'source_slippage': '0',
   'destination_account': addresses.COUNTERPARTY,
@@ -37,7 +37,7 @@ module.exports.paymentRestComplex = {
   'destination_amount': {
     'value': '10',
     'currency': 'USD',
-    'counterparty': addresses.VALID
+    'issuer': addresses.VALID
   },
   'invoice_id': '',
   'paths': '[]',
@@ -126,16 +126,16 @@ module.exports.exportsPaymentRestIssuers = function(options) {
     source_tag: '',
     source_amount: {
       value: options.sourceValue,
-      currency: 'USD',
-      counterparty: options.sourceIssuer
+        currency: 'USD',
+        issuer: options.sourceIssuer
     },
     source_slippage: options.sourceSlippage,
-    destination_account: options.destinationAccount,
-    destination_tag: '',
-    destination_amount: {
+      destination_account: options.destinationAccount,
+      destination_tag: '',
+      destination_amount: {
       value: '10',
-      currency: 'USD',
-      counterparty: options.destinationIssuer
+        currency: 'USD',
+        issuer: options.destinationIssuer
     },
     invoice_id: '',
     paths: '[]',

--- a/test/unit/fixtures/rest-converter.js
+++ b/test/unit/fixtures/rest-converter.js
@@ -1,3 +1,5 @@
+/* eslint-disable new-cap */
+/* eslint-disable max-len */
 'use strict';
 
 var _ = require('lodash');

--- a/test/unit/fixtures/tx-converter.js
+++ b/test/unit/fixtures/tx-converter.js
@@ -380,13 +380,13 @@ module.exports.paymentTx = function(options) {
 module.exports.paymentRest = {
   source_account: addresses.VALID,
   source_tag: '',
-  source_amount: { value: '1.112209', currency: 'XRP', counterparty: '' },
+  source_amount: { value: '1.112209', currency: 'XRP', issuer: '' },
   source_slippage: '0',
   destination_account: addresses.ISSUER,
   destination_tag: '',
   destination_amount:
   { currency: 'USD',
-    counterparty: addresses.ISSUER,
+    issuer: addresses.ISSUER,
     value: '0.001' },
   invoice_id: '',
   paths: '[[{"currency":"USD","issuer":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","type":48,"type_hex":"0000000000000030"},{"account":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","currency":"USD","issuer":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","type":49,"type_hex":"0000000000000031"}]]',
@@ -400,24 +400,24 @@ module.exports.paymentRest = {
     {
       currency: 'XRP',
       value: '-1.101208',
-      counterparty: ''
+      issuer: ''
     }
   ],
-  source_balance_changes: [ { value: '-1.101208', currency: 'XRP', counterparty: '' } ],
+  source_balance_changes: [ { value: '-1.101208', currency: 'XRP', issuer: '' } ],
   destination_balance_changes:
     [ { value: '0.001',
       currency: 'USD',
-      counterparty: addresses.COUNTERPARTY } ],
+      issuer: addresses.COUNTERPARTY } ],
   order_changes: [
     {
       taker_pays: {
         currency: 'XRP',
-        counterparty: '',
+        issuer: '',
         value: '-1.101198',
       },
       taker_gets: {
         currency: 'USD',
-        counterparty: addresses.COUNTERPARTY,
+        issuer: addresses.COUNTERPARTY,
         value: '-0.001002',
       },
       sequence: 58,
@@ -736,7 +736,7 @@ module.exports.pathPaymentsRest = [
     "source_amount": {
       "value": "0.1117218827811721",
       "currency": "JPY",
-      "counterparty": ""
+      "issuer": ""
     },
     "source_slippage": "0",
     "destination_account": addresses.VALID,
@@ -744,7 +744,7 @@ module.exports.pathPaymentsRest = [
     "destination_amount": {
       "value": "100",
       "currency": "USD",
-      "counterparty": addresses.ISSUER
+      "issuer": addresses.ISSUER
     },
     "invoice_id": "",
     "paths": "[[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -757,7 +757,7 @@ module.exports.pathPaymentsRest = [
     "source_amount": {
       "value": "0.001002",
       "currency": "USD",
-      "counterparty": ""
+      "issuer": ""
     },
     "source_slippage": "0",
     "destination_account": addresses.VALID,
@@ -765,7 +765,7 @@ module.exports.pathPaymentsRest = [
     "destination_amount": {
       "value": "100",
       "currency": "USD",
-      "counterparty": addresses.ISSUER
+      "issuer": addresses.ISSUER
     },
     "invoice_id": "",
     "paths": "[[{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
@@ -778,7 +778,7 @@ module.exports.pathPaymentsRest = [
     "source_amount": {
       "value": "0.207669",
       "currency": "XRP",
-      "counterparty": ""
+      "issuer": ""
     },
     "source_slippage": "0",
     "destination_account": addresses.VALID,
@@ -786,7 +786,7 @@ module.exports.pathPaymentsRest = [
     "destination_amount": {
       "value": "100",
       "currency": "USD",
-      "counterparty": addresses.ISSUER
+      "issuer": addresses.ISSUER
     },
     "invoice_id": "",
     "paths": "[[{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rf9X8QoYnWLHMHuDfjkmRcD2UE5qX5aYV\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rfQPFZ3eLcaSUKjUy7A3LAmDNM4F9Hz9j1\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",

--- a/test/unit/fixtures/tx-converter.js
+++ b/test/unit/fixtures/tx-converter.js
@@ -1,395 +1,399 @@
-var _         = require('lodash');
+/* eslint-disable new-cap */
+/* eslint-disable max-len */
+'use strict';
+
+var _ = require('lodash');
 var addresses = require('./../../fixtures').addresses;
 
-const VALID_TRANSACTION_HASH = 'F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF';
+var VALID_TRANSACTION_HASH = 'F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF';
 
 // VALID's EUR balance with ISSUER goes down from 6.948 to 6.113
 // VALID's XRP balance goes down 15000 drops for the fee
 // rGAW's USD balance with ISSUER goes down from 615 to 614
 // rGAW's EUR balance with ISSUER goes up from 9988 to 9989
 module.exports.COMPLICATED_META = {
-  AffectedNodes : [
+  AffectedNodes: [
     {
-      ModifiedNode : {
-        FinalFields : {
-          Balance : {
-            currency : "EUR",
-            issuer : "rrrrrrrrrrrrrrrrrrrrBZbvji",
-            value : "-6.113114000000012"
-          },
-          Flags : 2228224,
-          HighLimit : {
-            currency : "EUR",
-            issuer : addresses.VALID,
-            value : "100"
-          },
-          HighNode : "0000000000000000",
-          LowLimit : {
-            currency : "EUR",
-            issuer : addresses.ISSUER,
-            value : "0"
-          },
-          LowNode : "0000000000000000"
-        },
-        LedgerEntryType : "RippleState",
-        LedgerIndex : "24D1C0A5010D55A17DF68086F66945393CC8DBFED112D31A51CDAB36550845AA",
-        PreviousFields : {
-          Balance : {
-            currency : "EUR",
-            issuer : "rrrrrrrrrrrrrrrrrrrrBZbvji",
-            value : "-6.948114000000011"
-          }
-        },
-        PreviousTxnID : "02B2AA7EBC3F484740FEA25268B208CDE84D69AC70C97FB7CF5CBF540FEDEE6C",
-        PreviousTxnLgrSeq : 10251451
-      }
-    },
+      ModifiedNode: {
+        FinalFields: {
+          Balance: {
+            currency: 'EUR',
+            issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+            value: '-6.113114000000012'
+         },
+          Flags: 2228224,
+          HighLimit: {
+            currency: 'EUR',
+            issuer: addresses.VALID,
+            value: '100'
+         },
+          HighNode: '0000000000000000',
+          LowLimit: {
+            currency: 'EUR',
+            issuer: addresses.ISSUER,
+            value: '0'
+         },
+          LowNode: '0000000000000000'
+       },
+        LedgerEntryType: 'RippleState',
+        LedgerIndex: '24D1C0A5010D55A17DF68086F66945393CC8DBFED112D31A51CDAB36550845AA',
+        PreviousFields: {
+          Balance: {
+            currency: 'EUR',
+            issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+            value: '-6.948114000000011'
+         }
+       },
+        PreviousTxnID: '02B2AA7EBC3F484740FEA25268B208CDE84D69AC70C97FB7CF5CBF540FEDEE6C',
+        PreviousTxnLgrSeq: 10251451
+     }
+   },
     {
-      ModifiedNode : {
-        FinalFields : {
-          Account : addresses.VALID,
-          Balance : "88622336",
-          Flags : 0,
-          OwnerCount : 1,
-          Sequence : 100
-        },
-        LedgerEntryType : "AccountRoot",
-        LedgerIndex : "3FF5B517FE080E470078AABEAF8FEE7FF07DB778B979E4DB580E2B74879D8E22",
-        PreviousFields : {
-          Balance : "88637336",
-          Sequence : 99
-        },
-        PreviousTxnID : "157DC6CB2E0F2118212B475FB3DEB0984FB74B5DF58829730BCCB44C79D9270D",
-        PreviousTxnLgrSeq : 10246850
-      }
-    },
+      ModifiedNode: {
+        FinalFields: {
+          Account: addresses.VALID,
+          Balance: '88622336',
+          Flags: 0,
+          OwnerCount: 1,
+          Sequence: 100
+       },
+        LedgerEntryType: 'AccountRoot',
+        LedgerIndex: '3FF5B517FE080E470078AABEAF8FEE7FF07DB778B979E4DB580E2B74879D8E22',
+        PreviousFields: {
+          Balance: '88637336',
+          Sequence: 99
+       },
+        PreviousTxnID: '157DC6CB2E0F2118212B475FB3DEB0984FB74B5DF58829730BCCB44C79D9270D',
+        PreviousTxnLgrSeq: 10246850
+     }
+   },
     {
-      ModifiedNode : {
-        FinalFields : {
-          Balance : {
-            currency : "USD",
-            issuer : "rrrrrrrrrrrrrrrrrrrrBZbvji",
-            value : "-614.2984464173688"
-          },
-          Flags : 131072,
-          HighLimit : {
-            currency : "USD",
-            issuer : "rGAWXLxpsy77vWxgYriPZE5ktUfqa6prbG",
-            value : "1000"
-          },
-          HighNode : "0000000000000000",
-          LowLimit : {
-            currency : "USD",
-            issuer : addresses.ISSUER,
-            value : "0"
-          },
-          LowNode : "0000000000000000"
-        },
-        LedgerEntryType : "RippleState",
-        LedgerIndex : "5DE72094CF0D34410C620A2003735FD4391FBA6F100D19A31CEFE4A4B1E9A116",
-        PreviousFields : {
-          Balance : {
-            currency : "USD",
-            issuer : "rrrrrrrrrrrrrrrrrrrrBZbvji",
-            value : "-615.2984464173688"
-          }
-        },
-        PreviousTxnID : "02B2AA7EBC3F484740FEA25268B208CDE84D69AC70C97FB7CF5CBF540FEDEE6C",
-        PreviousTxnLgrSeq : 10251451
-      }
-    },
+      ModifiedNode: {
+        FinalFields: {
+          Balance: {
+            currency: 'USD',
+            issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+            value: '-614.2984464173688'
+         },
+          Flags: 131072,
+          HighLimit: {
+            currency: 'USD',
+            issuer: 'rGAWXLxpsy77vWxgYriPZE5ktUfqa6prbG',
+            value: '1000'
+         },
+          HighNode: '0000000000000000',
+          LowLimit: {
+            currency: 'USD',
+            issuer: addresses.ISSUER,
+            value: '0'
+         },
+          LowNode: '0000000000000000'
+       },
+        LedgerEntryType: 'RippleState',
+        LedgerIndex: '5DE72094CF0D34410C620A2003735FD4391FBA6F100D19A31CEFE4A4B1E9A116',
+        PreviousFields: {
+          Balance: {
+            currency: 'USD',
+            issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+            value: '-615.2984464173688'
+         }
+       },
+        PreviousTxnID: '02B2AA7EBC3F484740FEA25268B208CDE84D69AC70C97FB7CF5CBF540FEDEE6C',
+        PreviousTxnLgrSeq: 10251451
+     }
+   },
     {
-      ModifiedNode : {
-        FinalFields : {
-          Balance : {
-            currency : "EUR",
-            issuer : "rrrrrrrrrrrrrrrrrrrrBZbvji",
-            value : "-9989.667799999999"
-          },
-          Flags : 131072,
-          HighLimit : {
-            currency : "EUR",
-            issuer : "rGAWXLxpsy77vWxgYriPZE5ktUfqa6prbG",
-            value : "10000000"
-          },
-          HighNode : "0000000000000000",
-          LowLimit : {
-            currency : "EUR",
-            issuer : addresses.ISSUER,
-            value : "0"
-          },
-          LowNode : "0000000000000000"
-        },
-        LedgerEntryType : "RippleState",
-        LedgerIndex : "6086D04C4C47B3F92B3EC0BA70BF762A13C7366299CEAA2E5F75666991AE28DF",
-        PreviousFields : {
-          Balance : {
-            currency : "EUR",
-            issuer : "rrrrrrrrrrrrrrrrrrrrBZbvji",
-            value : "-9988.834466666666"
-          }
-        },
-        PreviousTxnID : "02B2AA7EBC3F484740FEA25268B208CDE84D69AC70C97FB7CF5CBF540FEDEE6C",
-        PreviousTxnLgrSeq : 10251451
-      }
-    },
+      ModifiedNode: {
+        FinalFields: {
+          Balance: {
+            currency: 'EUR',
+            issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+            value: '-9989.667799999999'
+         },
+          Flags: 131072,
+          HighLimit: {
+            currency: 'EUR',
+            issuer: 'rGAWXLxpsy77vWxgYriPZE5ktUfqa6prbG',
+            value: '10000000'
+         },
+          HighNode: '0000000000000000',
+          LowLimit: {
+            currency: 'EUR',
+            issuer: addresses.ISSUER,
+            value: '0'
+         },
+          LowNode: '0000000000000000'
+       },
+        LedgerEntryType: 'RippleState',
+        LedgerIndex: '6086D04C4C47B3F92B3EC0BA70BF762A13C7366299CEAA2E5F75666991AE28DF',
+        PreviousFields: {
+          Balance: {
+            currency: 'EUR',
+            issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+            value: '-9988.834466666666'
+         }
+       },
+        PreviousTxnID: '02B2AA7EBC3F484740FEA25268B208CDE84D69AC70C97FB7CF5CBF540FEDEE6C',
+        PreviousTxnLgrSeq: 10251451
+     }
+   },
     {
-      ModifiedNode : {
-        FinalFields : {
-          Account : "rGAWXLxpsy77vWxgYriPZE5ktUfqa6prbG",
-          BookDirectory : "B939D46F734C31872A8B6C423F61FA2D2743F0622661668D541D9B1F5D20D554",
-          BookNode : "0000000000000000",
-          Flags : 0,
-          OwnerNode : "0000000000000000",
-          Sequence : 56,
-          TakerGets : {
-            currency : "USD",
-            issuer : addresses.ISSUER,
-            value : "488"
-          },
-          TakerPays : {
-            currency : "EUR",
-            issuer : addresses.ISSUER,
-            value : "406.6666666666667"
-          }
-        },
-        LedgerEntryType : "Offer",
-        LedgerIndex : "A19F21722E4361EA4495DE7EF2CCE362367C43196620B68D563B661CFEA4AFAE",
-        PreviousFields : {
-          TakerGets : {
-            currency : "USD",
-            issuer : addresses.ISSUER,
-            value : "489"
-          },
-          TakerPays : {
-            currency : "EUR",
-            issuer : addresses.ISSUER,
-            value : "407.5"
-          }
-        },
-        PreviousTxnID : "157DC6CB2E0F2118212B475FB3DEB0984FB74B5DF58829730BCCB44C79D9270D",
-        PreviousTxnLgrSeq : 10246850
-      }
-    }
-  ]
+      ModifiedNode: {
+        FinalFields: {
+          Account: 'rGAWXLxpsy77vWxgYriPZE5ktUfqa6prbG',
+          BookDirectory: 'B939D46F734C31872A8B6C423F61FA2D2743F0622661668D541D9B1F5D20D554',
+          BookNode: '0000000000000000',
+          Flags: 0,
+          OwnerNode: '0000000000000000',
+          Sequence: 56,
+          TakerGets: {
+            currency: 'USD',
+            issuer: addresses.ISSUER,
+            value: '488'
+         },
+          TakerPays: {
+            currency: 'EUR',
+            issuer: addresses.ISSUER,
+            value: '406.6666666666667'
+         }
+       },
+        LedgerEntryType: 'Offer',
+        LedgerIndex: 'A19F21722E4361EA4495DE7EF2CCE362367C43196620B68D563B661CFEA4AFAE',
+        PreviousFields: {
+          TakerGets: {
+            currency: 'USD',
+            issuer: addresses.ISSUER,
+            value: '489'
+         },
+          TakerPays: {
+            currency: 'EUR',
+            issuer: addresses.ISSUER,
+            value: '407.5'
+         }
+       },
+        PreviousTxnID: '157DC6CB2E0F2118212B475FB3DEB0984FB74B5DF58829730BCCB44C79D9270D',
+        PreviousTxnLgrSeq: 10246850
+     }
+   }
+ ]
 };
 
 module.exports.paymentTx = function(options) {
   options = options || {};
   _.defaults(options, {
     meta: {
-      "AffectedNodes": [
+      'AffectedNodes': [
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Account": addresses.VALID,
-              "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5E03E788E09BB000",
-              "BookNode": "0000000000000000",
-              "Flags": 0,
-              "OwnerNode": "0000000000000000",
-              "Sequence": 58,
-              "TakerGets": {
-                "currency": "USD",
-                "issuer": addresses.COUNTERPARTY,
-                "value": "5.648998"
-              },
-              "TakerPays": "6208248802"
-            },
-            "LedgerEntryType": "Offer",
-            "LedgerIndex": "3CFB3C79D4F1BDB1EE5245259372576D926D9A875713422F7169A6CC60AFA68B",
-            "PreviousFields": {
-              "TakerGets": {
-                "currency": "USD",
-                "issuer": addresses.COUNTERPARTY,
-                "value": "5.65"
-              },
-              "TakerPays": "6209350000"
-            },
-            "PreviousTxnID": "8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4",
-            "PreviousTxnLgrSeq": 348433
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Account': addresses.VALID,
+              'BookDirectory': '4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5E03E788E09BB000',
+              'BookNode': '0000000000000000',
+              'Flags': 0,
+              'OwnerNode': '0000000000000000',
+              'Sequence': 58,
+              'TakerGets': {
+                'currency': 'USD',
+                'issuer': addresses.COUNTERPARTY,
+                'value': '5.648998'
+             },
+              'TakerPays': '6208248802'
+           },
+            'LedgerEntryType': 'Offer',
+            'LedgerIndex': '3CFB3C79D4F1BDB1EE5245259372576D926D9A875713422F7169A6CC60AFA68B',
+            'PreviousFields': {
+              'TakerGets': {
+                'currency': 'USD',
+                'issuer': addresses.COUNTERPARTY,
+                'value': '5.65'
+             },
+              'TakerPays': '6209350000'
+           },
+            'PreviousTxnID': '8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4',
+            'PreviousTxnLgrSeq': 348433
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-0.001"
-              },
-              "Flags": 131072,
-              "HighLimit": {
-                "currency": "USD",
-                "issuer": addresses.ISSUER,
-                "value": "1"
-              },
-              "HighNode": "0000000000000000",
-              "LowLimit": {
-                "currency": "USD",
-                "issuer": addresses.COUNTERPARTY,
-                "value": "0"
-              },
-              "LowNode": "0000000000000002"
-            },
-            "LedgerEntryType": "RippleState",
-            "LedgerIndex": "4BD1874F8F3A60EDB0C23F5BD43E07953C2B8741B226648310D113DE2B486F01",
-            "PreviousFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "0"
-              }
-            },
-            "PreviousTxnID": "5B2006DAD0B3130F57ACF7CC5CCAC2EEBCD4B57AAA091A6FD0A24B073D08ABB8",
-            "PreviousTxnLgrSeq": 343703
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-0.001'
+             },
+              'Flags': 131072,
+              'HighLimit': {
+                'currency': 'USD',
+                'issuer': addresses.ISSUER,
+                'value': '1'
+             },
+              'HighNode': '0000000000000000',
+              'LowLimit': {
+                'currency': 'USD',
+                'issuer': addresses.COUNTERPARTY,
+                'value': '0'
+             },
+              'LowNode': '0000000000000002'
+           },
+            'LedgerEntryType': 'RippleState',
+            'LedgerIndex': '4BD1874F8F3A60EDB0C23F5BD43E07953C2B8741B226648310D113DE2B486F01',
+            'PreviousFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '0'
+             }
+           },
+            'PreviousTxnID': '5B2006DAD0B3130F57ACF7CC5CCAC2EEBCD4B57AAA091A6FD0A24B073D08ABB8',
+            'PreviousTxnLgrSeq': 343703
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Account": addresses.VALID,
-              "Balance": "9998898762",
-              "Flags": 0,
-              "OwnerCount": 3,
-              "Sequence": 5
-            },
-            "LedgerEntryType": "AccountRoot",
-            "LedgerIndex": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
-            "PreviousFields": {
-              "Balance": "9999999970",
-              "Sequence": 4
-            },
-            "PreviousTxnID": "53354D84BAE8FDFC3F4DA879D984D24B929E7FEB9100D2AD9EFCD2E126BCCDC8",
-            "PreviousTxnLgrSeq": 343570
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Account': addresses.VALID,
+              'Balance': '9998898762',
+              'Flags': 0,
+              'OwnerCount': 3,
+              'Sequence': 5
+           },
+            'LedgerEntryType': 'AccountRoot',
+            'LedgerIndex': '4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05',
+            'PreviousFields': {
+              'Balance': '9999999970',
+              'Sequence': 4
+           },
+            'PreviousTxnID': '53354D84BAE8FDFC3F4DA879D984D24B929E7FEB9100D2AD9EFCD2E126BCCDC8',
+            'PreviousTxnLgrSeq': 343570
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Account": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
-              "Balance": "912695302618",
-              "Flags": 0,
-              "OwnerCount": 10,
-              "Sequence": 59
-            },
-            "LedgerEntryType": "AccountRoot",
-            "LedgerIndex": "F3E119AAA87AF3607CF87F5523BB8278A83BCB4142833288305D767DD30C392A",
-            "PreviousFields": {
-              "Balance": "912694201420"
-            },
-            "PreviousTxnID": "8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4",
-            "PreviousTxnLgrSeq": 348433
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Account': 'r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr',
+              'Balance': '912695302618',
+              'Flags': 0,
+              'OwnerCount': 10,
+              'Sequence': 59
+           },
+            'LedgerEntryType': 'AccountRoot',
+            'LedgerIndex': 'F3E119AAA87AF3607CF87F5523BB8278A83BCB4142833288305D767DD30C392A',
+            'PreviousFields': {
+              'Balance': '912694201420'
+           },
+            'PreviousTxnID': '8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4',
+            'PreviousTxnLgrSeq': 348433
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-5.5541638883365"
-              },
-              "Flags": 131072,
-              "HighLimit": {
-                "currency": "USD",
-                "issuer": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
-                "value": "1000"
-              },
-              "HighNode": "0000000000000000",
-              "LowLimit": {
-                "currency": "USD",
-                "issuer": addresses.COUNTERPARTY,
-                "value": "0"
-              },
-              "LowNode": "000000000000000C"
-            },
-            "LedgerEntryType": "RippleState",
-            "LedgerIndex": "FA1255C2E0407F1945BCF9351257C7C5C28B0F5F09BB81C08D35A03E9F0136BC",
-            "PreviousFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-5.5551658883365"
-              }
-            },
-            "PreviousTxnID": "8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4",
-            "PreviousTxnLgrSeq": 348433
-          }
-        }
-      ],
-      "TransactionIndex": 0,
-      "TransactionResult": "tesSUCCESS"
-    },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-5.5541638883365'
+             },
+              'Flags': 131072,
+              'HighLimit': {
+                'currency': 'USD',
+                'issuer': 'r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr',
+                'value': '1000'
+             },
+              'HighNode': '0000000000000000',
+              'LowLimit': {
+                'currency': 'USD',
+                'issuer': addresses.COUNTERPARTY,
+                'value': '0'
+             },
+              'LowNode': '000000000000000C'
+           },
+            'LedgerEntryType': 'RippleState',
+            'LedgerIndex': 'FA1255C2E0407F1945BCF9351257C7C5C28B0F5F09BB81C08D35A03E9F0136BC',
+            'PreviousFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-5.5551658883365'
+             }
+           },
+            'PreviousTxnID': '8F571C346688D89AC1F737AE3B6BB5D976702B171CC7B4DE5CA3D444D5B8D6B4',
+            'PreviousTxnLgrSeq': 348433
+         }
+       }
+     ],
+      'TransactionIndex': 0,
+      'TransactionResult': 'tesSUCCESS'
+   },
     hash: VALID_TRANSACTION_HASH
-  });
+ });
 
   return {
-    "Account": addresses.VALID,
-    "Amount": {
-      "currency": "USD",
-      "issuer": addresses.ISSUER,
-      "value": "0.001"
-    },
-    "Destination": addresses.ISSUER,
-    "Fee": "10",
-    "Flags": 0,
-    "Memos": [
+    'Account': addresses.VALID,
+    'Amount': {
+      'currency': 'USD',
+      'issuer': addresses.ISSUER,
+      'value': '0.001'
+   },
+    'Destination': addresses.ISSUER,
+    'Fee': '10',
+    'Flags': 0,
+    'Memos': [
       {
-        "Memo": {
-          "MemoData": "736F6D655F76616C7565",
-          "MemoType": "736F6D655F6B6579"
-        }
-      },
+        'Memo': {
+          'MemoData': '736F6D655F76616C7565',
+          'MemoType': '736F6D655F6B6579'
+       }
+     },
       {
-        "Memo": {
-          "MemoData": "736F6D655F76616C7565"
-        }
-      }
-    ],
-    "Paths": [
+        'Memo': {
+          'MemoData': '736F6D655F76616C7565'
+       }
+     }
+   ],
+    'Paths': [
       [
         {
-          "currency": "USD",
-          "issuer": addresses.COUNTERPARTY,
-          "type": 48,
-          "type_hex": "0000000000000030"
-        },
+          'currency': 'USD',
+          'issuer': addresses.COUNTERPARTY,
+          'type': 48,
+          'type_hex': '0000000000000030'
+       },
         {
-          "account": addresses.COUNTERPARTY,
-          "currency": "USD",
-          "issuer": addresses.COUNTERPARTY,
-          "type": 49,
-          "type_hex": "0000000000000031"
-        }
-      ]
-    ],
-    "SendMax": "1112209",
-    "Sequence": 4,
-    "SigningPubKey": "02BC8C02199949B15C005B997E7C8594574E9B02BA2D0628902E0532989976CF9D",
-    "TransactionType": "Payment",
-    "TxnSignature": "304502204EE3E9D1B01D8959B08450FCA9E22025AF503DEF310E34A93863A85CAB3C0BC5022100B61F5B567F77026E8DEED89EED0B7CAF0E6C96C228A2A65216F0DC2D04D52083",
-    "date": 416447810,
-    "hash": options.hash,
-    "inLedger": 348860,
-    "ledger_index": 348860,
-    "meta": options.meta,
-    "validated": true
-  };
+          'account': addresses.COUNTERPARTY,
+          'currency': 'USD',
+          'issuer': addresses.COUNTERPARTY,
+          'type': 49,
+          'type_hex': '0000000000000031'
+       }
+     ]
+   ],
+    'SendMax': '1112209',
+    'Sequence': 4,
+    'SigningPubKey': '02BC8C02199949B15C005B997E7C8594574E9B02BA2D0628902E0532989976CF9D',
+    'TransactionType': 'Payment',
+    'TxnSignature': '304502204EE3E9D1B01D8959B08450FCA9E22025AF503DEF310E34A93863A85CAB3C0BC5022100B61F5B567F77026E8DEED89EED0B7CAF0E6C96C228A2A65216F0DC2D04D52083',
+    'date': 416447810,
+    'hash': options.hash,
+    'inLedger': 348860,
+    'ledger_index': 348860,
+    'meta': options.meta,
+    'validated': true
+ };
 };
 
 module.exports.paymentRest = {
   source_account: addresses.VALID,
   source_tag: '',
-  source_amount: { value: '1.112209', currency: 'XRP', issuer: '' },
+  source_amount: {value: '1.112209', currency: 'XRP', issuer: ''},
   source_slippage: '0',
   destination_account: addresses.ISSUER,
   destination_tag: '',
   destination_amount:
-  { currency: 'USD',
+  {currency: 'USD',
     issuer: addresses.ISSUER,
-    value: '0.001' },
+    value: '0.001'},
   invoice_id: '',
-  paths: '[[{"currency":"USD","issuer":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","type":48,"type_hex":"0000000000000030"},{"account":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","currency":"USD","issuer":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","type":49,"type_hex":"0000000000000031"}]]',
+  paths: '[[{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":49,\"type_hex\":\"0000000000000031\"}]]',
   no_direct_ripple: false,
   partial_payment: false,
   direction: 'outgoing',
@@ -401,500 +405,500 @@ module.exports.paymentRest = {
       currency: 'XRP',
       value: '-1.101208',
       issuer: ''
-    }
-  ],
-  source_balance_changes: [ { value: '-1.101208', currency: 'XRP', issuer: '' } ],
+   }
+ ],
+  source_balance_changes: [{value: '-1.101208', currency: 'XRP', issuer: ''}],
   destination_balance_changes:
-    [ { value: '0.001',
+    [{value: '0.001',
       currency: 'USD',
-      issuer: addresses.COUNTERPARTY } ],
+      issuer: addresses.COUNTERPARTY}],
   order_changes: [
     {
       taker_pays: {
         currency: 'XRP',
         issuer: '',
-        value: '-1.101198',
-      },
+        value: '-1.101198'
+     },
       taker_gets: {
         currency: 'USD',
         issuer: addresses.COUNTERPARTY,
-        value: '-0.001002',
-      },
+        value: '-0.001002'
+     },
       sequence: 58,
       status: 'open'
-    }
-  ],
+   }
+ ],
   memos:
-    [ { MemoData: '736F6D655F76616C7565',
-      MemoType: '736F6D655F6B6579' },
-      { MemoData: '736F6D655F76616C7565' } ] };
+    [{MemoData: '736F6D655F76616C7565',
+      MemoType: '736F6D655F6B6579'},
+      {MemoData: '736F6D655F76616C7565'}]};
 
 
 module.exports.pathFindResultsTx = {
-  "alternatives": [
+  'alternatives': [
     {
-      "paths_canonical": [],
-      "paths_computed": [
+      'paths_canonical': [],
+      'paths_computed': [
         [
           {
-            "account": "rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "currency": "USD",
-            "issuer": addresses.ISSUER,
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': addresses.ISSUER,
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "account": "rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "currency": "XRP",
-            "type": 16,
-            "type_hex": "0000000000000010"
-          },
+            'currency': 'XRP',
+            'type': 16,
+            'type_hex': '0000000000000010'
+         },
           {
-            "currency": "USD",
-            "issuer": addresses.ISSUER,
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': addresses.ISSUER,
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "account": "rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "currency": "XRP",
-            "type": 16,
-            "type_hex": "0000000000000010"
-          },
+            'currency': 'XRP',
+            'type': 16,
+            'type_hex': '0000000000000010'
+         },
           {
-            "currency": "USD",
-            "issuer": "rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT",
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': 'rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT',
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": "rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "account": "rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "currency": "XRP",
-            "type": 16,
-            "type_hex": "0000000000000010"
-          },
+            'currency': 'XRP',
+            'type': 16,
+            'type_hex': '0000000000000010'
+         },
           {
-            "currency": "USD",
-            "issuer": "rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9",
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': 'rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9',
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": "rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ]
-      ],
-      "source_amount": {
-        "currency": "JPY",
-        "value": "0.1117218827811721"
-      }
-    },
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ]
+     ],
+      'source_amount': {
+        'currency': 'JPY',
+        'value': '0.1117218827811721'
+     }
+   },
     {
-      "paths_canonical": [],
-      "paths_computed": [
+      'paths_canonical': [],
+      'paths_computed': [
         [
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "currency": "USD",
-            "issuer": addresses.ISSUER,
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': addresses.ISSUER,
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "currency": "XRP",
-            "type": 16,
-            "type_hex": "0000000000000010"
-          },
+            'currency': 'XRP',
+            'type': 16,
+            'type_hex': '0000000000000010'
+         },
           {
-            "currency": "USD",
-            "issuer": addresses.ISSUER,
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': addresses.ISSUER,
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "currency": "XRP",
-            "type": 16,
-            "type_hex": "0000000000000010"
-          },
+            'currency': 'XRP',
+            'type': 16,
+            'type_hex': '0000000000000010'
+         },
           {
-            "currency": "USD",
-            "issuer": "rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT",
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': 'rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT',
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": "rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ]
-      ],
-      "source_amount": {
-        "currency": "USD",
-        "issuer": addresses.VALID,
-        "value": "0.001002"
-      }
-    },
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ]
+     ],
+      'source_amount': {
+        'currency': 'USD',
+        'issuer': addresses.VALID,
+        'value': '0.001002'
+     }
+   },
     {
-      "paths_canonical": [],
-      "paths_computed": [
+      'paths_canonical': [],
+      'paths_computed': [
         [
           {
-            "currency": "USD",
-            "issuer": addresses.ISSUER,
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': addresses.ISSUER,
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "currency": "USD",
-            "issuer": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc",
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': 'rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc',
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "account": "rf9X8QoYnWLHMHuDfjkmRcD2UE5qX5aYV",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rf9X8QoYnWLHMHuDfjkmRcD2UE5qX5aYV',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "currency": "USD",
-            "issuer": "rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT",
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': 'rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT',
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": "rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "account": "rfQPFZ3eLcaSUKjUy7A3LAmDNM4F9Hz9j1",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rfQPFZ3eLcaSUKjUy7A3LAmDNM4F9Hz9j1',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ],
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ],
         [
           {
-            "currency": "USD",
-            "issuer": "rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT",
-            "type": 48,
-            "type_hex": "0000000000000030"
-          },
+            'currency': 'USD',
+            'issuer': 'rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT',
+            'type': 48,
+            'type_hex': '0000000000000030'
+         },
           {
-            "account": "rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT",
-            "type": 1,
-            "type_hex": "0000000000000001"
-          },
+            'account': 'rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT',
+            'type': 1,
+            'type_hex': '0000000000000001'
+         },
           {
-            "account": addresses.ISSUER,
-            "type": 1,
-            "type_hex": "0000000000000001"
-          }
-        ]
-      ],
-      "source_amount": "207669"
-    }
-  ],
-  "destination_account": addresses.VALID,
-  "destination_currencies": [
-    "USD",
-    "JOE",
-    "BTC",
-    "DYM",
-    "CNY",
-    "EUR",
-    "015841551A748AD2C1F76FF6ECB0CCCD00000000",
-    "MXN",
-    "XRP"
-  ],
-  "source_account": addresses.VALID,
-  "destination_amount": {
-    "value": "100",
-    "currency": "USD",
-    "issuer": addresses.ISSUER
-  }
+            'account': addresses.ISSUER,
+            'type': 1,
+            'type_hex': '0000000000000001'
+         }
+       ]
+     ],
+      'source_amount': '207669'
+   }
+ ],
+  'destination_account': addresses.VALID,
+  'destination_currencies': [
+    'USD',
+    'JOE',
+    'BTC',
+    'DYM',
+    'CNY',
+    'EUR',
+    '015841551A748AD2C1F76FF6ECB0CCCD00000000',
+    'MXN',
+    'XRP'
+ ],
+  'source_account': addresses.VALID,
+  'destination_amount': {
+    'value': '100',
+    'currency': 'USD',
+    'issuer': addresses.ISSUER
+ }
 };
 
 
 module.exports.pathPaymentsRest = [
   {
-    "source_account": addresses.VALID,
-    "source_tag": "",
-    "source_amount": {
-      "value": "0.1117218827811721",
-      "currency": "JPY",
-      "issuer": ""
-    },
-    "source_slippage": "0",
-    "destination_account": addresses.VALID,
-    "destination_tag": "",
-    "destination_amount": {
-      "value": "100",
-      "currency": "USD",
-      "issuer": addresses.ISSUER
-    },
-    "invoice_id": "",
-    "paths": "[[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
-    "partial_payment": false,
-    "no_direct_ripple": false
-  },
+    'source_account': addresses.VALID,
+    'source_tag': '',
+    'source_amount': {
+      'value': '0.1117218827811721',
+      'currency': 'JPY',
+      'issuer': ''
+   },
+    'source_slippage': '0',
+    'destination_account': addresses.VALID,
+    'destination_tag': '',
+    'destination_amount': {
+      'value': '100',
+      'currency': 'USD',
+      'issuer': addresses.ISSUER
+   },
+    'invoice_id': '',
+    'paths': '[[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMAz5ZnK73nyNUL4foAvaxdreczCkG3vA6\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rHHa9t2kLQyXRbdLkSzEgkzwf9unmFgZs9\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]',
+    'partial_payment': false,
+    'no_direct_ripple': false
+ },
   {
-    "source_account": addresses.VALID,
-    "source_tag": "",
-    "source_amount": {
-      "value": "0.001002",
-      "currency": "USD",
-      "issuer": ""
-    },
-    "source_slippage": "0",
-    "destination_account": addresses.VALID,
-    "destination_tag": "",
-    "destination_amount": {
-      "value": "100",
-      "currency": "USD",
-      "issuer": addresses.ISSUER
-    },
-    "invoice_id": "",
-    "paths": "[[{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
-    "partial_payment": false,
-    "no_direct_ripple": false
-  },
+    'source_account': addresses.VALID,
+    'source_tag': '',
+    'source_amount': {
+      'value': '0.001002',
+      'currency': 'USD',
+      'issuer': ''
+   },
+    'source_slippage': '0',
+    'destination_account': addresses.VALID,
+    'destination_tag': '',
+    'destination_amount': {
+      'value': '100',
+      'currency': 'USD',
+      'issuer': addresses.ISSUER
+   },
+    'invoice_id': '',
+    'paths': '[[{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]',
+    'partial_payment': false,
+    'no_direct_ripple': false
+ },
   {
-    "source_account": addresses.VALID,
-    "source_tag": "",
-    "source_amount": {
-      "value": "0.207669",
-      "currency": "XRP",
-      "issuer": ""
-    },
-    "source_slippage": "0",
-    "destination_account": addresses.VALID,
-    "destination_tag": "",
-    "destination_amount": {
-      "value": "100",
-      "currency": "USD",
-      "issuer": addresses.ISSUER
-    },
-    "invoice_id": "",
-    "paths": "[[{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rf9X8QoYnWLHMHuDfjkmRcD2UE5qX5aYV\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rfQPFZ3eLcaSUKjUy7A3LAmDNM4F9Hz9j1\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
-    "partial_payment": false,
-    "no_direct_ripple": false
-  }
+    'source_account': addresses.VALID,
+    'source_tag': '',
+    'source_amount': {
+      'value': '0.207669',
+      'currency': 'XRP',
+      'issuer': ''
+   },
+    'source_slippage': '0',
+    'destination_account': addresses.VALID,
+    'destination_tag': '',
+    'destination_amount': {
+      'value': '100',
+      'currency': 'USD',
+      'issuer': addresses.ISSUER
+   },
+    'invoice_id': '',
+    'paths': '[[{\"currency\":\"USD\",\"issuer\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rf9X8QoYnWLHMHuDfjkmRcD2UE5qX5aYV\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rDVdJ62foD1sn7ZpxtXyptdkBSyhsQGviT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rfQPFZ3eLcaSUKjUy7A3LAmDNM4F9Hz9j1\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"currency\":\"USD\",\"issuer\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpHgehzdpfWRXKvSv6duKvVuo1aZVimdaT\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]',
+    'partial_payment': false,
+    'no_direct_ripple': false
+ }
 ];
 
 module.exports.cancelOrderTx = {
-  "engine_result": "tesSUCCESS",
-  "engine_result_code": 0,
-  "engine_result_message": "The transaction was applied.",
-  "ledger_hash": "22148DA306D45FA966F0AA2A667078AF80E782D02A21E346A7F49E07A274F186",
-  "ledger_index": 10073361,
-  "status": "closed",
-  "type": "transaction",
-  "validated": true,
-  "metadata": {
-    "AffectedNodes": [
+  'engine_result': 'tesSUCCESS',
+  'engine_result_code': 0,
+  'engine_result_message': 'The transaction was applied.',
+  'ledger_hash': '22148DA306D45FA966F0AA2A667078AF80E782D02A21E346A7F49E07A274F186',
+  'ledger_index': 10073361,
+  'status': 'closed',
+  'type': 'transaction',
+  'validated': true,
+  'metadata': {
+    'AffectedNodes': [
       {
-        "DeletedNode": {
-          "FinalFields": {
-            "Account": addresses.VALID,
-            "BookDirectory": "3B95C29205977C2136BBC70F21895F8C8F471C8522BF446E5905AF3107A40000",
-            "BookNode": "0000000000000000",
-            "Flags": 2148007936,
-            "OwnerNode": "0000000000000000",
-            "PreviousTxnID": "052D575D49936BAF2DC674C2A80D6E19995FC8197577B8EB6163D31DA49D0D9E",
-            "PreviousTxnLgrSeq": 10073252,
-            "Sequence": 99,
-            "TakerGets": {
-              "currency": "USD",
-              "issuer": addresses.ISSUER,
-              "value": "100"
-            },
-            "TakerPays": {
-              "currency": "JPY",
-              "issuer": addresses.ISSUER,
-              "value": "10000"
-            }
-          },
-          "LedgerEntryType": "Offer",
-          "LedgerIndex": "093E00CAE2C35822017F99E27C2BD1FED6730858D109E3F5FA4C9FD8C9640453"
-        }
-      },
+        'DeletedNode': {
+          'FinalFields': {
+            'Account': addresses.VALID,
+            'BookDirectory': '3B95C29205977C2136BBC70F21895F8C8F471C8522BF446E5905AF3107A40000',
+            'BookNode': '0000000000000000',
+            'Flags': 2148007936,
+            'OwnerNode': '0000000000000000',
+            'PreviousTxnID': '052D575D49936BAF2DC674C2A80D6E19995FC8197577B8EB6163D31DA49D0D9E',
+            'PreviousTxnLgrSeq': 10073252,
+            'Sequence': 99,
+            'TakerGets': {
+              'currency': 'USD',
+              'issuer': addresses.ISSUER,
+              'value': '100'
+           },
+            'TakerPays': {
+              'currency': 'JPY',
+              'issuer': addresses.ISSUER,
+              'value': '10000'
+           }
+         },
+          'LedgerEntryType': 'Offer',
+          'LedgerIndex': '093E00CAE2C35822017F99E27C2BD1FED6730858D109E3F5FA4C9FD8C9640453'
+       }
+     },
       {
-        "DeletedNode": {
-          "FinalFields": {
-            "ExchangeRate": "5905AF3107A40000",
-            "Flags": 0,
-            "RootIndex": "3B95C29205977C2136BBC70F21895F8C8F471C8522BF446E5905AF3107A40000",
-            "TakerGetsCurrency": "0000000000000000000000005553440000000000",
-            "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
-            "TakerPaysCurrency": "0000000000000000000000004A50590000000000",
-            "TakerPaysIssuer": "E5C92828261DBAAC933B6309C6F5C72AF020AFD4"
-          },
-          "LedgerEntryType": "DirectoryNode",
-          "LedgerIndex": "3B95C29205977C2136BBC70F21895F8C8F471C8522BF446E5905AF3107A40000"
-        }
-      },
+        'DeletedNode': {
+          'FinalFields': {
+            'ExchangeRate': '5905AF3107A40000',
+            'Flags': 0,
+            'RootIndex': '3B95C29205977C2136BBC70F21895F8C8F471C8522BF446E5905AF3107A40000',
+            'TakerGetsCurrency': '0000000000000000000000005553440000000000',
+            'TakerGetsIssuer': '0A20B3C85F482532A9578DBB3950B85CA06594D1',
+            'TakerPaysCurrency': '0000000000000000000000004A50590000000000',
+            'TakerPaysIssuer': 'E5C92828261DBAAC933B6309C6F5C72AF020AFD4'
+         },
+          'LedgerEntryType': 'DirectoryNode',
+          'LedgerIndex': '3B95C29205977C2136BBC70F21895F8C8F471C8522BF446E5905AF3107A40000'
+       }
+     },
       {
-        "ModifiedNode": {
-          "FinalFields": {
-            "Flags": 0,
-            "Owner": addresses.VALID,
-            "RootIndex": "4CC6A36EE801B2A3A3B2E2C44857631BAF1A7FD1CAF73BAD55EB6F584815858A"
-          },
-          "LedgerEntryType": "DirectoryNode",
-          "LedgerIndex": "4CC6A36EE801B2A3A3B2E2C44857631BAF1A7FD1CAF73BAD55EB6F584815858A"
-        }
-      },
+        'ModifiedNode': {
+          'FinalFields': {
+            'Flags': 0,
+            'Owner': addresses.VALID,
+            'RootIndex': '4CC6A36EE801B2A3A3B2E2C44857631BAF1A7FD1CAF73BAD55EB6F584815858A'
+         },
+          'LedgerEntryType': 'DirectoryNode',
+          'LedgerIndex': '4CC6A36EE801B2A3A3B2E2C44857631BAF1A7FD1CAF73BAD55EB6F584815858A'
+       }
+     },
       {
-        "ModifiedNode": {
-          "FinalFields": {
-            "Account": addresses.VALID,
-            "Balance": "511738048423",
-            "Flags": 0,
-            "OwnerCount": 5,
-            "Sequence": 101
-          },
-          "LedgerEntryType": "AccountRoot",
-          "LedgerIndex": "53539B9154C83B7D657103C27ABCA0EF1AD3674F6D0B341F20710FC50EC4DC03",
-          "PreviousFields": {
-            "Balance": "511738060423",
-            "OwnerCount": 6,
-            "Sequence": 100
-          },
-          "PreviousTxnID": "052D575D49936BAF2DC674C2A80D6E19995FC8197577B8EB6163D31DA49D0D9E",
-          "PreviousTxnLgrSeq": 10073252
-        }
-      }
-    ],
-    "TransactionIndex": 8,
-    "TransactionResult": "tesSUCCESS"
-  },
-  "tx_json": {
-    "Account": addresses.VALID,
-    "Fee": "12000",
-    "Flags": 2147483648,
-    "LastLedgerSequence": 10073368,
-    "OfferSequence": 99,
-    "Sequence": 100,
-    "SigningPubKey": "02AC2A11C997C04EC6A4139E6189111F90E89D05F9A9DDC3E2CA459CEA89C539D3",
-    "TransactionType": "OfferCancel",
-    "TxnSignature": "3044022063C7C53712737A8715EF940F954C80D72C54D0D82DD01426059AEE147A831815022042CE97F22661B80897D07BAB6B66E80C184D424778062343881063E695AC0E7E",
-    "date": 469910420,
-    "hash": "3fc6fe4050075aa3115f212b64d97565ccd8003412f6404478a256b2f48351f3"
-  }
+        'ModifiedNode': {
+          'FinalFields': {
+            'Account': addresses.VALID,
+            'Balance': '511738048423',
+            'Flags': 0,
+            'OwnerCount': 5,
+            'Sequence': 101
+         },
+          'LedgerEntryType': 'AccountRoot',
+          'LedgerIndex': '53539B9154C83B7D657103C27ABCA0EF1AD3674F6D0B341F20710FC50EC4DC03',
+          'PreviousFields': {
+            'Balance': '511738060423',
+            'OwnerCount': 6,
+            'Sequence': 100
+         },
+          'PreviousTxnID': '052D575D49936BAF2DC674C2A80D6E19995FC8197577B8EB6163D31DA49D0D9E',
+          'PreviousTxnLgrSeq': 10073252
+       }
+     }
+   ],
+    'TransactionIndex': 8,
+    'TransactionResult': 'tesSUCCESS'
+ },
+  'tx_json': {
+    'Account': addresses.VALID,
+    'Fee': '12000',
+    'Flags': 2147483648,
+    'LastLedgerSequence': 10073368,
+    'OfferSequence': 99,
+    'Sequence': 100,
+    'SigningPubKey': '02AC2A11C997C04EC6A4139E6189111F90E89D05F9A9DDC3E2CA459CEA89C539D3',
+    'TransactionType': 'OfferCancel',
+    'TxnSignature': '3044022063C7C53712737A8715EF940F954C80D72C54D0D82DD01426059AEE147A831815022042CE97F22661B80897D07BAB6B66E80C184D424778062343881063E695AC0E7E',
+    'date': 469910420,
+    'hash': '3fc6fe4050075aa3115f212b64d97565ccd8003412f6404478a256b2f48351f3'
+ }
 };
 
 module.exports.cancelOrderResponseRest = {
@@ -903,39 +907,39 @@ module.exports.cancelOrderResponseRest = {
     fee: '0.012',
     offer_sequence: 99,
     sequence: 100
-  },
+ },
   hash: '3fc6fe4050075aa3115f212b64d97565ccd8003412f6404478a256b2f48351f3',
   ledger: '8819996',
   state: 'validated'
 };
 
 module.exports.submitOrderResponseTx = {
-  "engine_result": "tesSUCCESS",
-  "engine_result_code": 0,
-  "engine_result_message": "The transaction was applied.",
-  "tx_blob": "12000722800800002400000063201B0099699B64D54E35FA931A00000000000000000000000000004A50590000000000E5C92828261DBAAC933B6309C6F5C72AF020AFD465D448E1BC9BF0400000000000000000000000000055534400000000000A20B3C85F482532A9578DBB3950B85CA06594D1684000000000002EE0732102AC2A11C997C04EC6A4139E6189111F90E89D05F9A9DDC3E2CA459CEA89C539D3744730450221009D829F972F220620D790E7C4028F311A338763F081758EBF7E2D320899D2831502204F0512873A2C96F087C3E8D98A33CB7316B9AA8C40DDB1A3D15F0206366B8AD48114E81DCB25DAA1DDEFF45145D334C56F12EA63C337",
-  "tx_json": {
-    "Account": addresses.VALID,
-    "Fee": "12000",
-    "Flags": 2148007936,
-    "LastLedgerSequence": 10054043,
-    "Sequence": 99,
-    "SigningPubKey": "02AC2A11C997C04EC6A4139E6189111F90E89D05F9A9DDC3E2CA459CEA89C539D3",
-    "TakerGets": {
-      "currency": "USD",
-      "issuer": addresses.ISSUER,
-      "value": "100"
-    },
-    "TakerPays": {
-      "currency": "JPY",
-      "issuer": addresses.ISSUER,
-      "value": "10000"
-    },
-    "TransactionType": "OfferCreate",
-    "TxnSignature": "30450221009D829F972F220620D790E7C4028F311A338763F081758EBF7E2D320899D2831502204F0512873A2C96F087C3E8D98A33CB7316B9AA8C40DDB1A3D15F0206366B8AD4",
-    "hash": "684fd723577624f4581fd35d3ada8ff9e536f0ce5ab2065a22adf81633be1f2c"
-  },
-  "result": "tesSUCCESS"
+  'engine_result': 'tesSUCCESS',
+  'engine_result_code': 0,
+  'engine_result_message': 'The transaction was applied.',
+  'tx_blob': '12000722800800002400000063201B0099699B64D54E35FA931A00000000000000000000000000004A50590000000000E5C92828261DBAAC933B6309C6F5C72AF020AFD465D448E1BC9BF0400000000000000000000000000055534400000000000A20B3C85F482532A9578DBB3950B85CA06594D1684000000000002EE0732102AC2A11C997C04EC6A4139E6189111F90E89D05F9A9DDC3E2CA459CEA89C539D3744730450221009D829F972F220620D790E7C4028F311A338763F081758EBF7E2D320899D2831502204F0512873A2C96F087C3E8D98A33CB7316B9AA8C40DDB1A3D15F0206366B8AD48114E81DCB25DAA1DDEFF45145D334C56F12EA63C337',
+  'tx_json': {
+    'Account': addresses.VALID,
+    'Fee': '12000',
+    'Flags': 2148007936,
+    'LastLedgerSequence': 10054043,
+    'Sequence': 99,
+    'SigningPubKey': '02AC2A11C997C04EC6A4139E6189111F90E89D05F9A9DDC3E2CA459CEA89C539D3',
+    'TakerGets': {
+      'currency': 'USD',
+      'issuer': addresses.ISSUER,
+      'value': '100'
+   },
+    'TakerPays': {
+      'currency': 'JPY',
+      'issuer': addresses.ISSUER,
+      'value': '10000'
+   },
+    'TransactionType': 'OfferCreate',
+    'TxnSignature': '30450221009D829F972F220620D790E7C4028F311A338763F081758EBF7E2D320899D2831502204F0512873A2C96F087C3E8D98A33CB7316B9AA8C40DDB1A3D15F0206366B8AD4',
+    'hash': '684fd723577624f4581fd35d3ada8ff9e536f0ce5ab2065a22adf81633be1f2c'
+ },
+  'result': 'tesSUCCESS'
 };
 
 module.exports.submitOrderResponseRest = {
@@ -945,103 +949,103 @@ module.exports.submitOrderResponseRest = {
       currency: 'USD',
       counterparty: addresses.ISSUER,
       value: '100'
-    },
+   },
     taker_pays: {
       currency: 'JPY',
       counterparty: addresses.ISSUER,
       value: '10000'
-    },
+   },
     fee: '0.012',
     type: 'sell',
     sequence: 99
-  },
+ },
   hash: '684fd723577624f4581fd35d3ada8ff9e536f0ce5ab2065a22adf81633be1f2c',
   ledger: '8819982',
-  state: 'pending',
+  state: 'pending'
 };
 
 module.exports.trustResponseTx = {
-  "engine_result": "tesSUCCESS",
-  "engine_result_code": 0,
-  "engine_result_message": "The transaction was applied.",
-  "ledger_hash": "E0B48625C74115865D83F777081163D1C33144AD11A3104292720092D2183770",
-  "ledger_index": 9810402,
-  "status": "closed",
-  "type": "transaction",
-  "validated": true,
-  "metadata": {
-    "AffectedNodes": [
+  'engine_result': 'tesSUCCESS',
+  'engine_result_code': 0,
+  'engine_result_message': 'The transaction was applied.',
+  'ledger_hash': 'E0B48625C74115865D83F777081163D1C33144AD11A3104292720092D2183770',
+  'ledger_index': 9810402,
+  'status': 'closed',
+  'type': 'transaction',
+  'validated': true,
+  'metadata': {
+    'AffectedNodes': [
       {
-        "ModifiedNode": {
-          "FinalFields": {
-            "Account": addresses.VALID,
-            "Balance": "792505355",
-            "Flags": 0,
-            "OwnerCount": 3,
-            "Sequence": 12
-          },
-          "LedgerEntryType": "AccountRoot",
-          "LedgerIndex": "25FF5CC1037AE7E2C491A2E4C6206CBE31D0F1609B6426E6E8C3626BAC8C3439",
-          "PreviousFields": {
-            "Balance": "792505367",
-            "Sequence": 11
-          },
-          "PreviousTxnID": "B7B913FC00AE7838238F5021CE88ED8A5D408110726BED719BDC2A024FAE793D",
-          "PreviousTxnLgrSeq": 9791833
-        }
-      },
+        'ModifiedNode': {
+          'FinalFields': {
+            'Account': addresses.VALID,
+            'Balance': '792505355',
+            'Flags': 0,
+            'OwnerCount': 3,
+            'Sequence': 12
+         },
+          'LedgerEntryType': 'AccountRoot',
+          'LedgerIndex': '25FF5CC1037AE7E2C491A2E4C6206CBE31D0F1609B6426E6E8C3626BAC8C3439',
+          'PreviousFields': {
+            'Balance': '792505367',
+            'Sequence': 11
+         },
+          'PreviousTxnID': 'B7B913FC00AE7838238F5021CE88ED8A5D408110726BED719BDC2A024FAE793D',
+          'PreviousTxnLgrSeq': 9791833
+       }
+     },
       {
-        "ModifiedNode": {
-          "FinalFields": {
-            "Balance": {
-              "currency": "USD",
-              "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-              "value": "0.2899999999999999"
-            },
-            "Flags": 1114112,
-            "HighLimit": {
-              "currency": "USD",
-              "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-              "value": "0"
-            },
-            "HighNode": "0000000000000163",
-            "LowLimit": {
-              "currency": "USD",
-              "issuer": addresses.VALID,
-              "value": "110"
-            },
-            "LowNode": "0000000000000000"
-          },
-          "LedgerEntryType": "RippleState",
-          "LedgerIndex": "620379E07473AAE2E6CCCB196AE9DD13C5D036C4B47211BB3DAA55D019CB2226",
-          "PreviousFields": {
-            "Flags": 65536
-          },
-          "PreviousTxnID": "A1344FACEAE2FA0EC795A1A64B972F144DDBBB1441B9C253BF63AC6294258287",
-          "PreviousTxnLgrSeq": 9791722
-        }
-      }
-    ],
-    "TransactionIndex": 0,
-    "TransactionResult": "tesSUCCESS"
-  },
-  "tx_json": {
-    "Account": addresses.VALID,
-    "Fee": "12",
-    "Flags": 2147614720,
-    "LastLedgerSequence": 9810409,
-    "LimitAmount": {
-      "currency": "USD",
-      "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-      "value": "110"
-    },
-    "Sequence": 11,
-    "SigningPubKey": "02AFA3692CC78A804ACC11DBA23DBB99943C6F8D61D3CB07BBE6D28356EB5B9C57",
-    "TransactionType": "TrustSet",
-    "TxnSignature": "304402201178957B6ABB7673DB21F05C58E66061D5C753B9D63158032B0C1CC9CB68C94802203CEB99C8B72BB33EF63684B2A6BF77A232448ECACBB5FFC9FD8DCC8065948847",
-    "date": 468718190,
-    "hash": "0F480D344CFC610DFA5CAC62CC1621C92953A05FE8C319281CA49C5C162AF40E"
-  }
+        'ModifiedNode': {
+          'FinalFields': {
+            'Balance': {
+              'currency': 'USD',
+              'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+              'value': '0.2899999999999999'
+           },
+            'Flags': 1114112,
+            'HighLimit': {
+              'currency': 'USD',
+              'issuer': 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q',
+              'value': '0'
+           },
+            'HighNode': '0000000000000163',
+            'LowLimit': {
+              'currency': 'USD',
+              'issuer': addresses.VALID,
+              'value': '110'
+           },
+            'LowNode': '0000000000000000'
+         },
+          'LedgerEntryType': 'RippleState',
+          'LedgerIndex': '620379E07473AAE2E6CCCB196AE9DD13C5D036C4B47211BB3DAA55D019CB2226',
+          'PreviousFields': {
+            'Flags': 65536
+         },
+          'PreviousTxnID': 'A1344FACEAE2FA0EC795A1A64B972F144DDBBB1441B9C253BF63AC6294258287',
+          'PreviousTxnLgrSeq': 9791722
+       }
+     }
+   ],
+    'TransactionIndex': 0,
+    'TransactionResult': 'tesSUCCESS'
+ },
+  'tx_json': {
+    'Account': addresses.VALID,
+    'Fee': '12',
+    'Flags': 2147614720,
+    'LastLedgerSequence': 9810409,
+    'LimitAmount': {
+      'currency': 'USD',
+      'issuer': 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q',
+      'value': '110'
+   },
+    'Sequence': 11,
+    'SigningPubKey': '02AFA3692CC78A804ACC11DBA23DBB99943C6F8D61D3CB07BBE6D28356EB5B9C57',
+    'TransactionType': 'TrustSet',
+    'TxnSignature': '304402201178957B6ABB7673DB21F05C58E66061D5C753B9D63158032B0C1CC9CB68C94802203CEB99C8B72BB33EF63684B2A6BF77A232448ECACBB5FFC9FD8DCC8065948847',
+    'date': 468718190,
+    'hash': '0F480D344CFC610DFA5CAC62CC1621C92953A05FE8C319281CA49C5C162AF40E'
+ }
 };
 
 module.exports.trustResponseRest = {
@@ -1053,31 +1057,31 @@ module.exports.trustResponseRest = {
     account_allows_rippling: false,
     account_trustline_frozen: false,
     authorized: undefined
-  },
+ },
   hash: '0F480D344CFC610DFA5CAC62CC1621C92953A05FE8C319281CA49C5C162AF40E',
   ledger: '8820111',
   state: 'validated'
 };
 
 module.exports.settingResponseTx = {
-  "engine_result": "tesSUCCESS",
-  "engine_result_code": 0,
-  "engine_result_message": "The transaction was applied.",
-  "tx_blob": "1200032280150000240000003B2B000000022C00000001201B0086956C2021000000072022000000064123463B99B62A72F26ED677CC556C44E85700000000000000000000000000000000000000000000000000000000DEADBEEF68400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D874473045022100F748627AA15F53CDDB4708892AA8378450C0AE20C193AD703C2941ED03762961022073B99149232EB07C0F2870EB2E55543C475E2059749EDABD949D09848BF0FBEE770B6578616D706C652E636F6D81144FBFF73DA4ECF9B701940F27341FA8020C313443",
-  "tx_json": {
-    "Account": addresses.VALID,
-    "Fee": "12",
-    "Flags": -2146107392,
-    "clearFlag": 6,
-    "SetFlag": 7,
-    "LastLedgerSequence": 8820076,
-    "Sequence": 2938,
-    "SigningPubKey": "02F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D8",
-    "TransactionType": "AccountSet",
-    "TxnSignature": "3044022013ED8E41507111736B4C5EC9E4C01A7B570B273B3DE21302F72D4D1B1F20C4EF0220180C1419108CA39A9FF89E12810EC7429E28468E8D0BA61F793E14DB8D9FEA72",
-    "hash": "AD922400CB1CE0876CA7203DBE0B1277D0D0EAC56A64F26CEC6C78D447EFEA5E"
-  },
-  "result": "tesSUCCESS"
+  'engine_result': 'tesSUCCESS',
+  'engine_result_code': 0,
+  'engine_result_message': 'The transaction was applied.',
+  'tx_blob': '1200032280150000240000003B2B000000022C00000001201B0086956C2021000000072022000000064123463B99B62A72F26ED677CC556C44E85700000000000000000000000000000000000000000000000000000000DEADBEEF68400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D874473045022100F748627AA15F53CDDB4708892AA8378450C0AE20C193AD703C2941ED03762961022073B99149232EB07C0F2870EB2E55543C475E2059749EDABD949D09848BF0FBEE770B6578616D706C652E636F6D81144FBFF73DA4ECF9B701940F27341FA8020C313443',
+  'tx_json': {
+    'Account': addresses.VALID,
+    'Fee': '12',
+    'Flags': -2146107392,
+    'clearFlag': 6,
+    'SetFlag': 7,
+    'LastLedgerSequence': 8820076,
+    'Sequence': 2938,
+    'SigningPubKey': '02F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D8',
+    'TransactionType': 'AccountSet',
+    'TxnSignature': '3044022013ED8E41507111736B4C5EC9E4C01A7B570B273B3DE21302F72D4D1B1F20C4EF0220180C1419108CA39A9FF89E12810EC7429E28468E8D0BA61F793E14DB8D9FEA72',
+    'hash': 'AD922400CB1CE0876CA7203DBE0B1277D0D0EAC56A64F26CEC6C78D447EFEA5E'
+ },
+  'result': 'tesSUCCESS'
 };
 
 module.exports.settingResponseRest = {
@@ -1096,390 +1100,390 @@ module.exports.settingResponseRest = {
     require_authorization: true,
     disallow_xrp: true,
     default_ripple: true
-  },
+ },
   hash: '0F480D344CFC610DFA5CAC62CC1621C92953A05FE8C319281CA49C5C162AF40E',
   ledger: 8820076,
   state: 'validated'
 };
 
 module.exports.offerCreateTx = {
-    "Account": "rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC",
-    "Fee": "20000",
-    "Flags": 131072,
-    "Sequence": 609776,
-    "SigningPubKey": "03917C08C81FEC424141C50A1C4B7C77A4B1563D51B7FA260797B9717F52C5E6D5",
-    "TakerGets": {
-      "currency": "BTC",
-      "issuer": addresses.VALID,
-      "value": "0.2167622002262332"
-    },
-    "TakerPays": {
-      "currency": "USD",
-      "issuer": addresses.VALID,
-      "value": "57.5510124906279"
-    },
-    "TransactionType": "OfferCreate",
-    "TxnSignature": "304402207E48A159CBA0491684C8BBE31DEF55859A7616EAA2339C43445CF0185DC20A07022017D442BB2F6AB8BB9925765A690473332D1C1157AE310409D3CFD45755708E6F",
-    "date": 474426920,
-    "hash": "0D13787384301F32E9E180C31F7F16EA0D2521783DBF71736B25AFF253FB6E11",
-    "inLedger": 11086861,
-    "ledger_index": 11086861,
-    "meta": {
-      "AffectedNodes": [
+    'Account': 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
+    'Fee': '20000',
+    'Flags': 131072,
+    'Sequence': 609776,
+    'SigningPubKey': '03917C08C81FEC424141C50A1C4B7C77A4B1563D51B7FA260797B9717F52C5E6D5',
+    'TakerGets': {
+      'currency': 'BTC',
+      'issuer': addresses.VALID,
+      'value': '0.2167622002262332'
+   },
+    'TakerPays': {
+      'currency': 'USD',
+      'issuer': addresses.VALID,
+      'value': '57.5510124906279'
+   },
+    'TransactionType': 'OfferCreate',
+    'TxnSignature': '304402207E48A159CBA0491684C8BBE31DEF55859A7616EAA2339C43445CF0185DC20A07022017D442BB2F6AB8BB9925765A690473332D1C1157AE310409D3CFD45755708E6F',
+    'date': 474426920,
+    'hash': '0D13787384301F32E9E180C31F7F16EA0D2521783DBF71736B25AFF253FB6E11',
+    'inLedger': 11086861,
+    'ledger_index': 11086861,
+    'meta': {
+      'AffectedNodes': [
         {
-          "DeletedNode": {
-            "FinalFields": {
-              "ExchangeRate": "520D604D6638790F",
-              "Flags": 0,
-              "RootIndex": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520D604D6638790F",
-              "TakerGetsCurrency": "0000000000000000000000005553440000000000",
-              "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
-              "TakerPaysCurrency": "0000000000000000000000004254430000000000",
-              "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
-            },
-            "LedgerEntryType": "DirectoryNode",
-            "LedgerIndex": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520D604D6638790F"
-          }
-        },
+          'DeletedNode': {
+            'FinalFields': {
+              'ExchangeRate': '520D604D6638790F',
+              'Flags': 0,
+              'RootIndex': '20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520D604D6638790F',
+              'TakerGetsCurrency': '0000000000000000000000005553440000000000',
+              'TakerGetsIssuer': '0A20B3C85F482532A9578DBB3950B85CA06594D1',
+              'TakerPaysCurrency': '0000000000000000000000004254430000000000',
+              'TakerPaysIssuer': '0A20B3C85F482532A9578DBB3950B85CA06594D1'
+           },
+            'LedgerEntryType': 'DirectoryNode',
+            'LedgerIndex': '20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520D604D6638790F'
+         }
+       },
         {
-          "DeletedNode": {
-            "FinalFields": {
-              "Account": addresses.VALID,
-              "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520D604D6638790F",
-              "BookNode": "0000000000000000",
-              "Flags": 0,
-              "OwnerNode": "0000000000000000",
-              "PreviousTxnID": "97AA291851DE9A894CFCCD4C69C96E9570F9182A5D39937463E1C80132DD65DE",
-              "PreviousTxnLgrSeq": 11086861,
-              "Sequence": 550,
-              "TakerGets": {
-                "currency": "USD",
-                "issuer": addresses.VALID,
-                "value": "0"
-              },
-              "TakerPays": {
-                "currency": "BTC",
-                "issuer": addresses.VALID,
-                "value": "0"
-              }
-            },
-            "LedgerEntryType": "Offer",
-            "LedgerIndex": "276522C8AAF28B5286C48E2373C119C48DAE78C3F8A047AAF67C22E4440C391B",
-            "PreviousFields": {
-              "TakerGets": {
-                "currency": "USD",
-                "issuer": addresses.VALID,
-                "value": "0.0000000036076"
-              },
-              "TakerPays": {
-                "currency": "BTC",
-                "issuer": addresses.VALID,
-                "value": "1358360000000000e-26"
-              }
-            }
-          }
-        },
+          'DeletedNode': {
+            'FinalFields': {
+              'Account': addresses.VALID,
+              'BookDirectory': '20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520D604D6638790F',
+              'BookNode': '0000000000000000',
+              'Flags': 0,
+              'OwnerNode': '0000000000000000',
+              'PreviousTxnID': '97AA291851DE9A894CFCCD4C69C96E9570F9182A5D39937463E1C80132DD65DE',
+              'PreviousTxnLgrSeq': 11086861,
+              'Sequence': 550,
+              'TakerGets': {
+                'currency': 'USD',
+                'issuer': addresses.VALID,
+                'value': '0'
+             },
+              'TakerPays': {
+                'currency': 'BTC',
+                'issuer': addresses.VALID,
+                'value': '0'
+             }
+           },
+            'LedgerEntryType': 'Offer',
+            'LedgerIndex': '276522C8AAF28B5286C48E2373C119C48DAE78C3F8A047AAF67C22E4440C391B',
+            'PreviousFields': {
+              'TakerGets': {
+                'currency': 'USD',
+                'issuer': addresses.VALID,
+                'value': '0.0000000036076'
+             },
+              'TakerPays': {
+                'currency': 'BTC',
+                'issuer': addresses.VALID,
+                'value': '1358360000000000e-26'
+             }
+           }
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Flags": 0,
-              "Owner": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
-              "RootIndex": "38D499A08201B64C001CF6B1803504373BFDA21A01302D3C0E78EF98544E9236"
-            },
-            "LedgerEntryType": "DirectoryNode",
-            "LedgerIndex": "38D499A08201B64C001CF6B1803504373BFDA21A01302D3C0E78EF98544E9236"
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Flags': 0,
+              'Owner': 'r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ',
+              'RootIndex': '38D499A08201B64C001CF6B1803504373BFDA21A01302D3C0E78EF98544E9236'
+           },
+            'LedgerEntryType': 'DirectoryNode',
+            'LedgerIndex': '38D499A08201B64C001CF6B1803504373BFDA21A01302D3C0E78EF98544E9236'
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Balance": {
-                "currency": "BTC",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-0.1151236147503502"
-              },
-              "Flags": 2228224,
-              "HighLimit": {
-                "currency": "BTC",
-                "issuer": "rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC",
-                "value": "0"
-              },
-              "HighNode": "0000000000000000",
-              "LowLimit": {
-                "currency": "BTC",
-                "issuer": addresses.VALID,
-                "value": "0"
-              },
-              "LowNode": "000000000000028F"
-            },
-            "LedgerEntryType": "RippleState",
-            "LedgerIndex": "42A6E9991D540C80BE4A43EF5254656DD862F602BBFF99BC576B44FBF6B7D775",
-            "PreviousFields": {
-              "Balance": {
-                "currency": "BTC",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-0.3322932790173214"
-              }
-            },
-            "PreviousTxnID": "B7CE60D440E11F31530E19A50A0775246102425D3594C9B886A7724BB1E58367",
-            "PreviousTxnLgrSeq": 11086861
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Balance': {
+                'currency': 'BTC',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-0.1151236147503502'
+             },
+              'Flags': 2228224,
+              'HighLimit': {
+                'currency': 'BTC',
+                'issuer': 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
+                'value': '0'
+             },
+              'HighNode': '0000000000000000',
+              'LowLimit': {
+                'currency': 'BTC',
+                'issuer': addresses.VALID,
+                'value': '0'
+             },
+              'LowNode': '000000000000028F'
+           },
+            'LedgerEntryType': 'RippleState',
+            'LedgerIndex': '42A6E9991D540C80BE4A43EF5254656DD862F602BBFF99BC576B44FBF6B7D775',
+            'PreviousFields': {
+              'Balance': {
+                'currency': 'BTC',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-0.3322932790173214'
+             }
+           },
+            'PreviousTxnID': 'B7CE60D440E11F31530E19A50A0775246102425D3594C9B886A7724BB1E58367',
+            'PreviousTxnLgrSeq': 11086861
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-23112.9993818472"
-              },
-              "Flags": 2228224,
-              "HighLimit": {
-                "currency": "USD",
-                "issuer": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
-                "value": "1000000000"
-              },
-              "HighNode": "0000000000000000",
-              "LowLimit": {
-                "currency": "USD",
-                "issuer": addresses.VALID,
-                "value": "0"
-              },
-              "LowNode": "0000000000000231"
-            },
-            "LedgerEntryType": "RippleState",
-            "LedgerIndex": "615463C4F78931AA3E2B65FE49C6DAAC25A456C15679E67D1C19CA0943D98C5A",
-            "PreviousFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-23112.99938185081"
-              }
-            },
-            "PreviousTxnID": "97AA291851DE9A894CFCCD4C69C96E9570F9182A5D39937463E1C80132DD65DE",
-            "PreviousTxnLgrSeq": 11086861
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-23112.9993818472'
+             },
+              'Flags': 2228224,
+              'HighLimit': {
+                'currency': 'USD',
+                'issuer': 'r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ',
+                'value': '1000000000'
+             },
+              'HighNode': '0000000000000000',
+              'LowLimit': {
+                'currency': 'USD',
+                'issuer': addresses.VALID,
+                'value': '0'
+             },
+              'LowNode': '0000000000000231'
+           },
+            'LedgerEntryType': 'RippleState',
+            'LedgerIndex': '615463C4F78931AA3E2B65FE49C6DAAC25A456C15679E67D1C19CA0943D98C5A',
+            'PreviousFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-23112.99938185081'
+             }
+           },
+            'PreviousTxnID': '97AA291851DE9A894CFCCD4C69C96E9570F9182A5D39937463E1C80132DD65DE',
+            'PreviousTxnLgrSeq': 11086861
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Balance": {
-                "currency": "BTC",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-20.18770947118515"
-              },
-              "Flags": 131072,
-              "HighLimit": {
-                "currency": "BTC",
-                "issuer": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
-                "value": "0"
-              },
-              "HighNode": "0000000000000000",
-              "LowLimit": {
-                "currency": "BTC",
-                "issuer": addresses.VALID,
-                "value": "0"
-              },
-              "LowNode": "00000000000002C4"
-            },
-            "LedgerEntryType": "RippleState",
-            "LedgerIndex": "817EB23FB16D8D17676F29055C989CDFB738B7FC310DF3AB5CA0D06AA2DC1326",
-            "PreviousFields": {
-              "Balance": {
-                "currency": "BTC",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-20.18770947117157"
-              }
-            },
-            "PreviousTxnID": "97AA291851DE9A894CFCCD4C69C96E9570F9182A5D39937463E1C80132DD65DE",
-            "PreviousTxnLgrSeq": 11086861
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Balance': {
+                'currency': 'BTC',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-20.18770947118515'
+             },
+              'Flags': 131072,
+              'HighLimit': {
+                'currency': 'BTC',
+                'issuer': 'r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ',
+                'value': '0'
+             },
+              'HighNode': '0000000000000000',
+              'LowLimit': {
+                'currency': 'BTC',
+                'issuer': addresses.VALID,
+                'value': '0'
+             },
+              'LowNode': '00000000000002C4'
+           },
+            'LedgerEntryType': 'RippleState',
+            'LedgerIndex': '817EB23FB16D8D17676F29055C989CDFB738B7FC310DF3AB5CA0D06AA2DC1326',
+            'PreviousFields': {
+              'Balance': {
+                'currency': 'BTC',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-20.18770947117157'
+             }
+           },
+            'PreviousTxnID': '97AA291851DE9A894CFCCD4C69C96E9570F9182A5D39937463E1C80132DD65DE',
+            'PreviousTxnLgrSeq': 11086861
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Balance": {
-                "currency": "BTC",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-42.47198893790961"
-              },
-              "Flags": 2228224,
-              "HighLimit": {
-                "currency": "BTC",
-                "issuer": "rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD",
-                "value": "150"
-              },
-              "HighNode": "0000000000000000",
-              "LowLimit": {
-                "currency": "BTC",
-                "issuer": addresses.VALID,
-                "value": "0"
-              },
-              "LowNode": "0000000000000201"
-            },
-            "LedgerEntryType": "RippleState",
-            "LedgerIndex": "C688AE8E51943530C931C3B838D15818BDA1F1B60B641B5F866B724AD7D3E79B",
-            "PreviousFields": {
-              "Balance": {
-                "currency": "BTC",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-42.25525274603999"
-              }
-            },
-            "PreviousTxnID": "1C749407E3676E77693694BEBC73C74196EA39C4EB2BB47781ABD65F4AB315E9",
-            "PreviousTxnLgrSeq": 11082323
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Balance': {
+                'currency': 'BTC',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-42.47198893790961'
+             },
+              'Flags': 2228224,
+              'HighLimit': {
+                'currency': 'BTC',
+                'issuer': 'rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD',
+                'value': '150'
+             },
+              'HighNode': '0000000000000000',
+              'LowLimit': {
+                'currency': 'BTC',
+                'issuer': addresses.VALID,
+                'value': '0'
+             },
+              'LowNode': '0000000000000201'
+           },
+            'LedgerEntryType': 'RippleState',
+            'LedgerIndex': 'C688AE8E51943530C931C3B838D15818BDA1F1B60B641B5F866B724AD7D3E79B',
+            'PreviousFields': {
+              'Balance': {
+                'currency': 'BTC',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-42.25525274603999'
+             }
+           },
+            'PreviousTxnID': '1C749407E3676E77693694BEBC73C74196EA39C4EB2BB47781ABD65F4AB315E9',
+            'PreviousTxnLgrSeq': 11082323
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-283631.3541172556"
-              },
-              "Flags": 2228224,
-              "HighLimit": {
-                "currency": "USD",
-                "issuer": "rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD",
-                "value": "5000000"
-              },
-              "HighNode": "0000000000000000",
-              "LowLimit": {
-                "currency": "USD",
-                "issuer": addresses.VALID,
-                "value": "0"
-              },
-              "LowNode": "0000000000000201"
-            },
-            "LedgerEntryType": "RippleState",
-            "LedgerIndex": "D8F66B71771581E6185072E5264B2C4C0F9C2CA642EE46B62D6F550D897D00FF",
-            "PreviousFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-283689.0202317675"
-              }
-            },
-            "PreviousTxnID": "0419F004A3084E93D4708EDA40D64A9F52F52EAA854961C23E2779EBE400AAD9",
-            "PreviousTxnLgrSeq": 11086605
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-283631.3541172556'
+             },
+              'Flags': 2228224,
+              'HighLimit': {
+                'currency': 'USD',
+                'issuer': 'rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD',
+                'value': '5000000'
+             },
+              'HighNode': '0000000000000000',
+              'LowLimit': {
+                'currency': 'USD',
+                'issuer': addresses.VALID,
+                'value': '0'
+             },
+              'LowNode': '0000000000000201'
+           },
+            'LedgerEntryType': 'RippleState',
+            'LedgerIndex': 'D8F66B71771581E6185072E5264B2C4C0F9C2CA642EE46B62D6F550D897D00FF',
+            'PreviousFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-283689.0202317675'
+             }
+           },
+            'PreviousTxnID': '0419F004A3084E93D4708EDA40D64A9F52F52EAA854961C23E2779EBE400AAD9',
+            'PreviousTxnLgrSeq': 11086605
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Account": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
-              "Balance": "52083119197",
-              "Flags": 0,
-              "OwnerCount": 8,
-              "Sequence": 553
-            },
-            "LedgerEntryType": "AccountRoot",
-            "LedgerIndex": "DD314C9308B172885F6D0F5F3F50A2EAB1D2E2BD75A65A4236547E9C1DD625DB",
-            "PreviousFields": {
-              "OwnerCount": 9
-            },
-            "PreviousTxnID": "F07EA8FA7FF285FA5EC5F5A36CCCFC0F3D4B9A9A2910EEABABF058F96F6CD402",
-            "PreviousTxnLgrSeq": 11082743
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Account': 'r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ',
+              'Balance': '52083119197',
+              'Flags': 0,
+              'OwnerCount': 8,
+              'Sequence': 553
+           },
+            'LedgerEntryType': 'AccountRoot',
+            'LedgerIndex': 'DD314C9308B172885F6D0F5F3F50A2EAB1D2E2BD75A65A4236547E9C1DD625DB',
+            'PreviousFields': {
+              'OwnerCount': 9
+           },
+            'PreviousTxnID': 'F07EA8FA7FF285FA5EC5F5A36CCCFC0F3D4B9A9A2910EEABABF058F96F6CD402',
+            'PreviousTxnLgrSeq': 11082743
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "-57.5510124906279"
-              },
-              "Flags": 2228224,
-              "HighLimit": {
-                "currency": "USD",
-                "issuer": "rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC",
-                "value": "0"
-              },
-              "HighNode": "0000000000000000",
-              "LowLimit": {
-                "currency": "USD",
-                "issuer": addresses.VALID,
-                "value": "0"
-              },
-              "LowNode": "000000000000028F"
-            },
-            "LedgerEntryType": "RippleState",
-            "LedgerIndex": "E929BE69F05FEB6B376C97E22A264D93D88A7E42BE3FE5BFBD1842AC08C85BCF",
-            "PreviousFields": {
-              "Balance": {
-                "currency": "USD",
-                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-                "value": "0"
-              }
-            },
-            "PreviousTxnID": "73867036670B2F95ADCFF006A253C700ED45EF83F1B125D4797F2C110B055B60",
-            "PreviousTxnLgrSeq": 11086861
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '-57.5510124906279'
+             },
+              'Flags': 2228224,
+              'HighLimit': {
+                'currency': 'USD',
+                'issuer': 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
+                'value': '0'
+             },
+              'HighNode': '0000000000000000',
+              'LowLimit': {
+                'currency': 'USD',
+                'issuer': addresses.VALID,
+                'value': '0'
+             },
+              'LowNode': '000000000000028F'
+           },
+            'LedgerEntryType': 'RippleState',
+            'LedgerIndex': 'E929BE69F05FEB6B376C97E22A264D93D88A7E42BE3FE5BFBD1842AC08C85BCF',
+            'PreviousFields': {
+              'Balance': {
+                'currency': 'USD',
+                'issuer': 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+                'value': '0'
+             }
+           },
+            'PreviousTxnID': '73867036670B2F95ADCFF006A253C700ED45EF83F1B125D4797F2C110B055B60',
+            'PreviousTxnLgrSeq': 11086861
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Account": "rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD",
-              "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520D61247A328674",
-              "BookNode": "0000000000000000",
-              "Flags": 0,
-              "OwnerNode": "000000000000001B",
-              "Sequence": 114646,
-              "TakerGets": {
-                "currency": "USD",
-                "issuer": addresses.VALID,
-                "value": "0.00000002162526"
-              },
-              "TakerPays": {
-                "currency": "BTC",
-                "issuer": addresses.VALID,
-                "value": "8144010000000000e-26"
-              }
-            },
-            "LedgerEntryType": "Offer",
-            "LedgerIndex": "E9F98B8933C500737D5FD0BCAFC49EADB8F8A9D01170EFB7CA171D0DEF853D02",
-            "PreviousFields": {
-              "TakerGets": {
-                "currency": "USD",
-                "issuer": addresses.VALID,
-                "value": "57.55101250864556"
-              },
-              "TakerPays": {
-                "currency": "BTC",
-                "issuer": addresses.VALID,
-                "value": "0.2167361919510613"
-              }
-            },
-            "PreviousTxnID": "23433B9508778BEE0E8CE398602BBEDAFAE210F59979BCAC818B6970DCCB91F5",
-            "PreviousTxnLgrSeq": 11080258
-          }
-        },
+          'ModifiedNode': {
+            'FinalFields': {
+              'Account': 'rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD',
+              'BookDirectory': '20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520D61247A328674',
+              'BookNode': '0000000000000000',
+              'Flags': 0,
+              'OwnerNode': '000000000000001B',
+              'Sequence': 114646,
+              'TakerGets': {
+                'currency': 'USD',
+                'issuer': addresses.VALID,
+                'value': '0.00000002162526'
+             },
+              'TakerPays': {
+                'currency': 'BTC',
+                'issuer': addresses.VALID,
+                'value': '8144010000000000e-26'
+             }
+           },
+            'LedgerEntryType': 'Offer',
+            'LedgerIndex': 'E9F98B8933C500737D5FD0BCAFC49EADB8F8A9D01170EFB7CA171D0DEF853D02',
+            'PreviousFields': {
+              'TakerGets': {
+                'currency': 'USD',
+                'issuer': addresses.VALID,
+                'value': '57.55101250864556'
+             },
+              'TakerPays': {
+                'currency': 'BTC',
+                'issuer': addresses.VALID,
+                'value': '0.2167361919510613'
+             }
+           },
+            'PreviousTxnID': '23433B9508778BEE0E8CE398602BBEDAFAE210F59979BCAC818B6970DCCB91F5',
+            'PreviousTxnLgrSeq': 11080258
+         }
+       },
         {
-          "ModifiedNode": {
-            "FinalFields": {
-              "Account": "rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC",
-              "Balance": "267312570945",
-              "Flags": 0,
-              "OwnerCount": 25,
-              "Sequence": 609777
-            },
-            "LedgerEntryType": "AccountRoot",
-            "LedgerIndex": "EAFF4A0B5E891B9BE6A4D484FD0A73356F099FA54F650C9D8FB35D3F29A44176",
-            "PreviousFields": {
-              "Balance": "267312590945",
-              "Sequence": 609776
-            },
-            "PreviousTxnID": "B7CE60D440E11F31530E19A50A0775246102425D3594C9B886A7724BB1E58367",
-            "PreviousTxnLgrSeq": 11086861
-          }
-        }
-      ],
-      "TransactionIndex": 48,
-      "TransactionResult": "tesSUCCESS"
-    },
-    "validated": true
+          'ModifiedNode': {
+            'FinalFields': {
+              'Account': 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
+              'Balance': '267312570945',
+              'Flags': 0,
+              'OwnerCount': 25,
+              'Sequence': 609777
+           },
+            'LedgerEntryType': 'AccountRoot',
+            'LedgerIndex': 'EAFF4A0B5E891B9BE6A4D484FD0A73356F099FA54F650C9D8FB35D3F29A44176',
+            'PreviousFields': {
+              'Balance': '267312590945',
+              'Sequence': 609776
+           },
+            'PreviousTxnID': 'B7CE60D440E11F31530E19A50A0775246102425D3594C9B886A7724BB1E58367',
+            'PreviousTxnLgrSeq': 11086861
+         }
+       }
+     ],
+      'TransactionIndex': 48,
+      'TransactionResult': 'tesSUCCESS'
+   },
+    'validated': true
 };
 
 module.exports.parsedOfferCreateTx = {
@@ -1491,141 +1495,141 @@ module.exports.parsedOfferCreateTx = {
   action: 'order_create',
   direction: 'incoming',
   order:
-   { account: 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
+   {account: 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
      taker_pays:
-      { currency: 'USD',
+      {currency: 'USD',
         counterparty: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
-        value: '57.5510124906279' },
+        value: '57.5510124906279'},
      taker_gets:
-      { currency: 'BTC',
+      {currency: 'BTC',
         counterparty: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
-        value: '0.2167622002262332' },
+        value: '0.2167622002262332'},
      passive: false,
      immediate_or_cancel: false,
      fill_or_kill: false,
      type: 'buy',
-     sequence: 609776 },
+     sequence: 609776},
   balance_changes:
-   [ { counterparty: 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
+   [{counterparty: 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
        currency: 'BTC',
-       value: '0.2171696642669712' },
-     { counterparty: 'r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ',
+       value: '0.2171696642669712'},
+     {counterparty: 'r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ',
        currency: 'USD',
-       value: '3.61e-9' },
-     { counterparty: 'r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ',
+       value: '3.61e-9'},
+     {counterparty: 'r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ',
        currency: 'BTC',
-       value: '-1.358e-11' },
-     { counterparty: 'rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD',
+       value: '-1.358e-11'},
+     {counterparty: 'rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD',
        currency: 'BTC',
-       value: '-0.21673619186962' },
-     { counterparty: 'rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD',
+       value: '-0.21673619186962'},
+     {counterparty: 'rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD',
        currency: 'USD',
-       value: '57.6661145119' },
-     { counterparty: 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
+       value: '57.6661145119'},
+     {counterparty: 'rBxy23n7ZFbUpS699rFVj1V9ZVhAq6EGwC',
        currency: 'USD',
-       value: '-57.5510124906279' } ],
+       value: '-57.5510124906279'}],
   order_changes:
-   [ { taker_pays:
-        { currency: 'BTC',
+   [{taker_pays:
+        {currency: 'BTC',
           counterparty: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
-          value: '-1.35836e-11' },
+          value: '-1.35836e-11'},
        taker_gets:
-        { currency: 'USD',
+        {currency: 'USD',
           counterparty: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
-          value: '-3.6076e-9' },
+          value: '-3.6076e-9'},
        sequence: 550,
-       status: 'closed' } ]
+       status: 'closed'}]
 };
 
 module.exports.offerCancelTx = {
-  "Account": addresses.VALID,
-  "Fee": "12000",
-  "Flags": 0,
-  "LastLedgerSequence": 11236701,
-  "OfferSequence": 20,
-  "Sequence": 22,
-  "SigningPubKey": "039549AB540046941E2BD313CB71F0EEA3A560B587AE4ED75A7120965A67E0D6E1",
-  "TransactionType": "OfferCancel",
-  "TxnSignature": "304402200E24DFA7B5F37675CCBE5370EDB51A8EC4E58D55D34ADC19505DE3EE686ED64B0220421C955F4F4D63DFA517E48F81393FB007035C18821D25D8EA8C36D9A71AF0F4",
-  "date": 475105560,
-  "hash": "3D948699072B40312AE313E7E8297EED83080C9A4D5B564BCACF0951ABF00AC5",
-  "inLedger": 11236693,
-  "ledger_index": 11236693,
-  "meta": {
-    "AffectedNodes": [
+  'Account': addresses.VALID,
+  'Fee': '12000',
+  'Flags': 0,
+  'LastLedgerSequence': 11236701,
+  'OfferSequence': 20,
+  'Sequence': 22,
+  'SigningPubKey': '039549AB540046941E2BD313CB71F0EEA3A560B587AE4ED75A7120965A67E0D6E1',
+  'TransactionType': 'OfferCancel',
+  'TxnSignature': '304402200E24DFA7B5F37675CCBE5370EDB51A8EC4E58D55D34ADC19505DE3EE686ED64B0220421C955F4F4D63DFA517E48F81393FB007035C18821D25D8EA8C36D9A71AF0F4',
+  'date': 475105560,
+  'hash': '3D948699072B40312AE313E7E8297EED83080C9A4D5B564BCACF0951ABF00AC5',
+  'inLedger': 11236693,
+  'ledger_index': 11236693,
+  'meta': {
+    'AffectedNodes': [
       {
-        "DeletedNode": {
-          "FinalFields": {
-            "Account": addresses.VALID,
-            "BookDirectory": "9F72CA02AB7CBA0FD97EA5F245C03EDC555C3FE97749CD425B038D7EA4C68000",
-            "BookNode": "0000000000000000",
-            "Flags": 0,
-            "OwnerNode": "0000000000000000",
-            "PreviousTxnID": "3D768E210A152DFA89C051FEFC26F2FFBF91AC8B794482B8DA906157D3B2C348",
-            "PreviousTxnLgrSeq": 11235523,
-            "Sequence": 20,
-            "TakerGets": {
-              "currency": "JPY",
-              "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
-              "value": "1000"
-            },
-            "TakerPays": "1000000000"
-          },
-          "LedgerEntryType": "Offer",
-          "LedgerIndex": "39A270DE16B6861952C5409626B0FA68FCC1089DD242AF55D8B1CAE6194C0E67"
-        }
-      },
+        'DeletedNode': {
+          'FinalFields': {
+            'Account': addresses.VALID,
+            'BookDirectory': '9F72CA02AB7CBA0FD97EA5F245C03EDC555C3FE97749CD425B038D7EA4C68000',
+            'BookNode': '0000000000000000',
+            'Flags': 0,
+            'OwnerNode': '0000000000000000',
+            'PreviousTxnID': '3D768E210A152DFA89C051FEFC26F2FFBF91AC8B794482B8DA906157D3B2C348',
+            'PreviousTxnLgrSeq': 11235523,
+            'Sequence': 20,
+            'TakerGets': {
+              'currency': 'JPY',
+              'issuer': 'r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN',
+              'value': '1000'
+           },
+            'TakerPays': '1000000000'
+         },
+          'LedgerEntryType': 'Offer',
+          'LedgerIndex': '39A270DE16B6861952C5409626B0FA68FCC1089DD242AF55D8B1CAE6194C0E67'
+       }
+     },
       {
-        "ModifiedNode": {
-          "FinalFields": {
-            "ExchangeRate": "5B038D7EA4C68000",
-            "Flags": 0,
-            "RootIndex": "9F72CA02AB7CBA0FD97EA5F245C03EDC555C3FE97749CD425B038D7EA4C68000",
-            "TakerGetsCurrency": "0000000000000000000000004A50590000000000",
-            "TakerGetsIssuer": "5BBC0F22F61D9224A110650CFE21CC0C4BE13098",
-            "TakerPaysCurrency": "0000000000000000000000000000000000000000",
-            "TakerPaysIssuer": "0000000000000000000000000000000000000000"
-          },
-          "LedgerEntryType": "DirectoryNode",
-          "LedgerIndex": "9F72CA02AB7CBA0FD97EA5F245C03EDC555C3FE97749CD425B038D7EA4C68000"
-        }
-      },
+        'ModifiedNode': {
+          'FinalFields': {
+            'ExchangeRate': '5B038D7EA4C68000',
+            'Flags': 0,
+            'RootIndex': '9F72CA02AB7CBA0FD97EA5F245C03EDC555C3FE97749CD425B038D7EA4C68000',
+            'TakerGetsCurrency': '0000000000000000000000004A50590000000000',
+            'TakerGetsIssuer': '5BBC0F22F61D9224A110650CFE21CC0C4BE13098',
+            'TakerPaysCurrency': '0000000000000000000000000000000000000000',
+            'TakerPaysIssuer': '0000000000000000000000000000000000000000'
+         },
+          'LedgerEntryType': 'DirectoryNode',
+          'LedgerIndex': '9F72CA02AB7CBA0FD97EA5F245C03EDC555C3FE97749CD425B038D7EA4C68000'
+       }
+     },
       {
-        "ModifiedNode": {
-          "FinalFields": {
-            "Account": addresses.VALID,
-            "Balance": "29988000",
-            "Flags": 0,
-            "OwnerCount": 1,
-            "Sequence": 23
-          },
-          "LedgerEntryType": "AccountRoot",
-          "LedgerIndex": "C666A91E2D289AB6DD1A44363E1F4714B60584AA79B2CBFBB3330236610E4E47",
-          "PreviousFields": {
-            "Balance": "30000000",
-            "OwnerCount": 2,
-            "Sequence": 22
-          },
-          "PreviousTxnID": "FC061E8B2FAE945F4F674E11D4EF25F3B951DEB9116CDE5506B35EF383DC8988",
-          "PreviousTxnLgrSeq": 11235525
-        }
-      },
+        'ModifiedNode': {
+          'FinalFields': {
+            'Account': addresses.VALID,
+            'Balance': '29988000',
+            'Flags': 0,
+            'OwnerCount': 1,
+            'Sequence': 23
+         },
+          'LedgerEntryType': 'AccountRoot',
+          'LedgerIndex': 'C666A91E2D289AB6DD1A44363E1F4714B60584AA79B2CBFBB3330236610E4E47',
+          'PreviousFields': {
+            'Balance': '30000000',
+            'OwnerCount': 2,
+            'Sequence': 22
+         },
+          'PreviousTxnID': 'FC061E8B2FAE945F4F674E11D4EF25F3B951DEB9116CDE5506B35EF383DC8988',
+          'PreviousTxnLgrSeq': 11235525
+       }
+     },
       {
-        "ModifiedNode": {
-          "FinalFields": {
-            "Flags": 0,
-            "Owner": addresses.VALID,
-            "RootIndex": "E8C9FDFB9C7494135DF41ED69DFD0B9747CFE0ADF046E32BA24510B6A1EFDAE0"
-          },
-          "LedgerEntryType": "DirectoryNode",
-          "LedgerIndex": "E8C9FDFB9C7494135DF41ED69DFD0B9747CFE0ADF046E32BA24510B6A1EFDAE0"
-        }
-      }
-    ],
-    "TransactionIndex": 2,
-    "TransactionResult": "tesSUCCESS"
-  },
-  "validated": true
+        'ModifiedNode': {
+          'FinalFields': {
+            'Flags': 0,
+            'Owner': addresses.VALID,
+            'RootIndex': 'E8C9FDFB9C7494135DF41ED69DFD0B9747CFE0ADF046E32BA24510B6A1EFDAE0'
+         },
+          'LedgerEntryType': 'DirectoryNode',
+          'LedgerIndex': 'E8C9FDFB9C7494135DF41ED69DFD0B9747CFE0ADF046E32BA24510B6A1EFDAE0'
+       }
+     }
+   ],
+    'TransactionIndex': 2,
+    'TransactionResult': 'tesSUCCESS'
+ },
+  'validated': true
 };
 
 module.exports.parsedOfferCancelTx = {
@@ -1637,17 +1641,17 @@ module.exports.parsedOfferCancelTx = {
   action: 'order_cancel',
   direction: 'outgoing',
   order:
-   { account: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
+   {account: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
      type: 'cancel',
      sequence: 22,
-     cancel_sequence: 20 },
-  balance_changes: [ { counterparty: '', currency: 'XRP', value: '-0.012' } ],
+     cancel_sequence: 20},
+  balance_changes: [{counterparty: '', currency: 'XRP', value: '-0.012'}],
   order_changes:
-   [ { taker_pays: { currency: 'XRP', counterparty: '', value: '0' },
+   [{taker_pays: {currency: 'XRP', counterparty: '', value: '0'},
        taker_gets:
-        { currency: 'JPY',
+        {currency: 'JPY',
           counterparty: 'r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN',
-          value: '0' },
+          value: '0'},
        sequence: 20,
-       status: 'canceled' } ]
+       status: 'canceled'}]
 };

--- a/test/unit/rest-converter-test.js
+++ b/test/unit/rest-converter-test.js
@@ -1,6 +1,10 @@
-var assert            = require('assert');
-var fixtures          = require('./fixtures').restConverter;
-var addresses         = require('./../fixtures').addresses;
+/* eslint-disable new-cap */
+/* eslint-disable max-len */
+'use strict';
+
+var assert = require('assert');
+var fixtures = require('./fixtures').restConverter;
+var addresses = require('./../fixtures').addresses;
 var restToTxConverter = require('./../../api/lib/rest-to-tx-converter.js');
 
 suite('unit - converter - Rest to Tx', function() {
@@ -31,18 +35,18 @@ suite('unit - converter - Rest to Tx', function() {
 
   test('convert() -- payment with currency that has same issuer for source and destination amount', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
-      sourceIssuer:  addresses.VALID,
+      sourceIssuer: addresses.VALID,
       destinationIssuer: addresses.VALID
     }), function(err, transaction) {
       assert.strictEqual(err, null);
-      assert.strictEqual(transaction.tx_json.SendMax, void(0));
+      assert.strictEqual(transaction.tx_json.SendMax, undefined);
       done();
     });
   });
 
   test('convert() -- payment with currency that has different issuers for source and destination amount', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
-      sourceIssuer:  addresses.VALID,
+      sourceIssuer: addresses.VALID,
       destinationIssuer: addresses.COUNTERPARTY
     }), function(err, transaction) {
       assert.strictEqual(err, null);
@@ -57,7 +61,7 @@ suite('unit - converter - Rest to Tx', function() {
 
   test('convert() -- payment with currency that has different issuers for source and destination amount and a source_slippage of 0.1', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
-      sourceIssuer:  addresses.VALID,
+      sourceIssuer: addresses.VALID,
       destinationIssuer: addresses.COUNTERPARTY,
       sourceSlippage: '0.1',
       sourceAmount: '10'

--- a/test/unit/rest-converter-test.js
+++ b/test/unit/rest-converter-test.js
@@ -29,7 +29,7 @@ suite('unit - converter - Rest to Tx', function() {
     });
   });
 
-  test('convert() -- payment with currency that has same counterpartes for source and destination amount', function(done) {
+  test('convert() -- payment with currency that has same issuer for source and destination amount', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
       sourceIssuer:  addresses.VALID,
       destinationIssuer: addresses.VALID
@@ -40,7 +40,7 @@ suite('unit - converter - Rest to Tx', function() {
     });
   });
 
-  test('convert() -- payment with currency that has different counterparties for source and destination amount', function(done) {
+  test('convert() -- payment with currency that has different issuers for source and destination amount', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
       sourceIssuer:  addresses.VALID,
       destinationIssuer: addresses.COUNTERPARTY
@@ -55,7 +55,7 @@ suite('unit - converter - Rest to Tx', function() {
     });
   });
 
-  test('convert() -- payment with currency that has different counterparties for source and destination amount and a source_slippage of 0.1', function(done) {
+  test('convert() -- payment with currency that has different issuers for source and destination amount and a source_slippage of 0.1', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
       sourceIssuer:  addresses.VALID,
       destinationIssuer: addresses.COUNTERPARTY,

--- a/test/unit/tx-converter-test.js
+++ b/test/unit/tx-converter-test.js
@@ -30,13 +30,13 @@ suite('unit - converter - Tx to Rest', function() {
       assert.strictEqual(err, null);
 
       assert.deepEqual(payment.source_balance_changes, [
-        { value: '-0.834999999999999', currency: 'EUR', counterparty: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
-        { value: '-0.015', currency: 'XRP', counterparty: '' }
+        { value: '-0.834999999999999', currency: 'EUR', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
+        { value: '-0.015', currency: 'XRP', issuer: '' }
       ]);
 
       assert.deepEqual(payment.destination_balance_changes, [
-        { value: '-1', currency: 'USD', counterparty: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
-        { value: '0.833333333333', currency: 'EUR', counterparty: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' }
+        { value: '-1', currency: 'USD', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
+        { value: '0.833333333333', currency: 'EUR', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' }
       ]);
 
       done();

--- a/test/unit/tx-converter-test.js
+++ b/test/unit/tx-converter-test.js
@@ -1,6 +1,10 @@
-var assert            = require('assert-diff');
-var fixtures          = require('./fixtures').txConverter;
-var addresses         = require('./../fixtures').addresses;
+/* eslint-disable new-cap */
+/* eslint-disable max-len */
+'use strict';
+
+var assert = require('assert-diff');
+var fixtures = require('./fixtures').txConverter;
+var addresses = require('./../fixtures').addresses;
 var txToRestConverter = require('./../../api/lib/tx-to-rest-converter.js');
 
 suite('unit - converter - Tx to Rest', function() {
@@ -30,13 +34,28 @@ suite('unit - converter - Tx to Rest', function() {
       assert.strictEqual(err, null);
 
       assert.deepEqual(payment.source_balance_changes, [
-        { value: '-0.834999999999999', currency: 'EUR', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
-        { value: '-0.015', currency: 'XRP', issuer: '' }
+        {
+          value: '-0.834999999999999',
+          currency: 'EUR',
+          issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH'
+        },
+        {
+          value: '-0.015',
+          currency: 'XRP',
+          issuer: ''}
       ]);
 
       assert.deepEqual(payment.destination_balance_changes, [
-        { value: '-1', currency: 'USD', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' },
-        { value: '0.833333333333', currency: 'EUR', issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH' }
+        {
+          value: '-1',
+          currency: 'USD',
+          issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH'
+        },
+        {
+         value: '0.833333333333',
+         currency: 'EUR',
+         issuer: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH'
+        }
       ]);
 
       done();
@@ -85,7 +104,7 @@ suite('unit - converter - Tx to Rest', function() {
 
   test('parseTrustResponseFromTx()', function(done) {
     var txMessage = fixtures.trustResponseTx;
-    var meta =  {
+    var meta = {
       hash: '0F480D344CFC610DFA5CAC62CC1621C92953A05FE8C319281CA49C5C162AF40E',
       ledger: '8820111',
       state: 'validated'
@@ -200,7 +219,7 @@ suite('unit - converter - Tx to Rest', function() {
 
     test('parse OfferCreate -- missing options.account', function(done) {
       var options = {
-        account: void(0)
+        account: undefined
       };
 
       txToRestConverter.parseOrderFromTx(fixtures.offerCreateTx, options)

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -199,6 +199,30 @@ suite('unit - utils.txFromRestAmount()', function() {
       issuer: addresses.COUNTERPARTY
     });
   });
+
+  test('txFromRestAmount() -- XRP, using issuer in amount', function() {
+    var amount = {
+      value: '1',
+      currency: 'XRP',
+      issuer: ''
+    };
+
+    assert.strictEqual(utils.txFromRestAmount(amount), '1000000');
+  });
+
+  test('txFromRestAmount() -- USD, using issuer in amount', function() {
+    var amount = {
+      value: '1',
+      currency: 'USD',
+      issuer: addresses.COUNTERPARTY
+    };
+
+    assert.deepEqual(utils.txFromRestAmount(amount), {
+      value: '1',
+      currency: 'USD',
+      issuer: addresses.COUNTERPARTY
+    });
+  });
 });
 
 suite('unit - utils.compareTransactions()', function() {

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -1,22 +1,24 @@
+'use strict';
+
 var assert = require('assert');
 var utils = require('../../api/lib/utils.js');
 var addresses = require('./../fixtures/addresses.js');
 
 suite('unit - utils.parseLedger()', function() {
-  const DEFAULT_LEDGER = 'validated';
+  var DEFAULT_LEDGER = 'validated';
 
   test('parseLedger() -- ledger (empty string)', function() {
     var ledger = '';
     assert.strictEqual(utils.parseLedger(ledger), DEFAULT_LEDGER);
   });
 
-  test('parseLedger() -- ledger (void)', function() {
-    var ledger = void(0);
-    assert.strictEqual(utils.parseLedger(ledger), DEFAULT_LEDGER);
+  test('parseLedger() -- ledger (undefined)', function() {
+    assert.strictEqual(utils.parseLedger(undefined), DEFAULT_LEDGER);
   });
 
   test('parseLedger() -- ledger (hash)', function() {
-    var ledger_hash = 'FD22E2A8D665A01711C0147173ECC0A32466BA976DE697E95197933311267BE8';
+    var ledger_hash =
+      'FD22E2A8D665A01711C0147173ECC0A32466BA976DE697E95197933311267BE8';
     assert.strictEqual(utils.parseLedger(ledger_hash), ledger_hash);
   });
 
@@ -61,15 +63,20 @@ suite('unit - utils.parseLedger()', function() {
   });
 
   test('parseLedger() -- ledger (invalid hash)', function() {
-    var ledger = 'FD22E2A8D665A01711C0147173ECC0A32466BA976DE697E95197933311267BE';
+    var ledger =
+      'FD22E2A8D665A01711C0147173ECC0A32466BA976DE697E95197933311267BE';
     assert.strictEqual(ledger.length, 63);
     assert.strictEqual(utils.parseLedger(ledger), DEFAULT_LEDGER);
   });
 });
 
 suite('unit - utils.parseCurrencyAmount()', function() {
-  const nativeAmount = '1000000';
-  const usdAmount = { currency: 'USD', issuer: 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q', amount: '100' };
+  var nativeAmount = '1000000';
+  var usdAmount = {
+    currency: 'USD',
+    issuer: 'rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q',
+    amount: '100'
+  };
 
   test('parseCurrencyAmount() -- XRP', function() {
     assert.deepEqual(utils.parseCurrencyAmount(nativeAmount), {
@@ -235,7 +242,7 @@ suite('unit - utils.compareTransactions()', function() {
       ledger_index: 2
     };
 
-    assert.strictEqual(utils.compareTransactions(tx1,tx2), -1);
+    assert.strictEqual(utils.compareTransactions(tx1, tx2), -1);
   });
 
   test('compareTransactions() -- same ledger', function() {
@@ -253,7 +260,7 @@ suite('unit - utils.compareTransactions()', function() {
       }
     };
 
-    assert.strictEqual(utils.compareTransactions(tx1,tx2), 1);
+    assert.strictEqual(utils.compareTransactions(tx1, tx2), 1);
   });
 
   test('compareTransactions() -- same transaction', function() {
@@ -264,7 +271,7 @@ suite('unit - utils.compareTransactions()', function() {
       }
     };
 
-    assert.strictEqual(utils.compareTransactions(tx1,tx1), 0);
+    assert.strictEqual(utils.compareTransactions(tx1, tx1), 0);
   });
 
 });


### PR DESCRIPTION
This reverts commit 013efaa3c0c4fab34faf1ba0fb90d4d765aff399.

Includes a few changes to keep existing endpoints consistent with using
counterparty.

Conflicts:
	README.md
	api/lib/rest-to-tx-converter.js
	api/lib/tx-to-rest-converter.js
	api/lib/utils.js
	api/orders.js
	api/payments.js
	test/_payments-test.js