### PR TITLE
[FIX] `source_slippage` should default to zero

### DIFF
--- a/api/lib/rest-to-tx-converter.js
+++ b/api/lib/rest-to-tx-converter.js
@@ -78,7 +78,7 @@ RestToTxConverter.prototype.convert = function(payment, callback) {
             && payment.source_amount.counterparty
             === payment.destination_amount.counterparty)) {
         var max_value = bignum(payment.source_amount.value)
-                        .plus(payment.source_slippage).toString();
+                        .plus(payment.source_slippage || 0).toString();
         if (payment.source_amount.currency === 'XRP') {
           transaction.sendMax(utils.xrpToDrops(max_value));
         } else {

--- a/test/unit/fixtures/rest-converter.js
+++ b/test/unit/fixtures/rest-converter.js
@@ -116,7 +116,6 @@ module.exports.exportsPaymentRestIssuers = function(options) {
     destinationAccount: addresses.COUNTERPARTY,
     sourceIssuer: addresses.VALID,
     destinationIssuer: addresses.COUNTERPARTY,
-    sourceSlippage: '0',
     sourceValue: '10'
   });
 

--- a/test/unit/fixtures/rest-converter.js
+++ b/test/unit/fixtures/rest-converter.js
@@ -1,46 +1,48 @@
-var _         = require('lodash');
+'use strict';
+
+var _ = require('lodash');
 var addresses = require('./../../fixtures').addresses;
 
 module.exports.paymentRest = {
-  "source_account": addresses.VALID,
-  "destination_account": addresses.COUNTERPARTY,
-  "destination_amount": {
-    "value": "0.001",
-    "currency": "USD",
-    "counterparty": addresses.COUNTERPARTY
+  'source_account': addresses.VALID,
+  'destination_account': addresses.COUNTERPARTY,
+  'destination_amount': {
+    'value': '0.001',
+    'currency': 'USD',
+    'counterparty': addresses.COUNTERPARTY
   }
 };
 
 module.exports.paymentRestXRP = {
-  "source_account": addresses.VALID,
-  "destination_account": addresses.COUNTERPARTY,
-  "destination_amount": {
-    "value": "1",
-    "currency": "XRP",
-    "counterparty": ""
+  'source_account': addresses.VALID,
+  'destination_account': addresses.COUNTERPARTY,
+  'destination_amount': {
+    'value': '1',
+    'currency': 'XRP',
+    'counterparty': ''
   }
 };
 
 module.exports.paymentRestComplex = {
-  "source_account": addresses.VALID,
-  "source_tag": "",
-  "source_amount": {
-    "value": "10",
-    "currency": "USD",
-    "counterparty": addresses.VALID
+  'source_account': addresses.VALID,
+  'source_tag': '',
+  'source_amount': {
+    'value': '10',
+    'currency': 'USD',
+    'counterparty': addresses.VALID
   },
-  "source_slippage": "0",
-  "destination_account": addresses.COUNTERPARTY,
-  "destination_tag": "",
-  "destination_amount": {
-    "value": "10",
-    "currency": "USD",
-    "counterparty": addresses.VALID
+  'source_slippage': '0',
+  'destination_account': addresses.COUNTERPARTY,
+  'destination_tag': '',
+  'destination_amount': {
+    'value': '10',
+    'currency': 'USD',
+    'counterparty': addresses.VALID
   },
-  "invoice_id": "",
-  "paths": "[]",
-  "partial_payment": false,
-  "no_direct_ripple": false
+  'invoice_id': '',
+  'paths': '[]',
+  'partial_payment': false,
+  'no_direct_ripple': false
 };
 
 module.exports.paymentTx = {
@@ -139,6 +141,6 @@ module.exports.exportsPaymentRestIssuers = function(options) {
     paths: '[]',
     partial_payment: false,
     no_direct_ripple: false
-  }
+  };
 
 };


### PR DESCRIPTION
- A SendMax value is calculated using source_slippage, but that is an
  optional parameter.

- Typical client error:

```json
{
   "success": false,
   "error_type": "transaction",
   "error": "plus() not a number: undefined"
}
```