### PR TITLE
[FIX] Payment state is pending until validated (RLJS-318)

### DIFF
--- a/api/payments.js
+++ b/api/payments.js
@@ -46,14 +46,19 @@ function formatPaymentHelper(account, transaction, callback) {
   }
 
   function getPaymentMetadata(_transaction) {
+    var clientResourceID = _transaction.client_resource_id || '';
+    var hash = _transaction.hash || '';
+
+    var ledger = !_.isUndefined(transaction.inLedger) ?
+      String(_transaction.inLedger) : String(_transaction.ledger_index);
+
+    var state = _transaction.validated === true ? 'validated' : 'pending';
+
     return {
-      client_resource_id: _transaction.client_resource_id || '',
-      hash: _transaction.hash || '',
-      ledger: !_.isUndefined(transaction.inLedger)
-        ? String(_transaction.inLedger) : String(_transaction.ledger_index),
-      state: _transaction.state || _transaction.meta
-        ? (_transaction.meta.TransactionResult === 'tesSUCCESS'
-            ? 'validated' : 'failed') : ''
+      client_resource_id: clientResourceID,
+      hash: hash,
+      ledger: ledger,
+      state: state
     };
   }
 
@@ -150,6 +155,7 @@ function submitPayment(account, payment, clientResourceID, secret,
     if (meta.state === 'validated') {
       var transaction = message.tx_json;
       transaction.meta = message.metadata;
+      transaction.validated = message.validated;
       transaction.ledger_index = transaction.inLedger = message.ledger_index;
 
       return formatPaymentHelper(payment.source_account, transaction,

--- a/api/transactions.js
+++ b/api/transactions.js
@@ -418,6 +418,7 @@ function getAccountTx(api, options, callback) {
       }
       var tx = tx_entry.tx;
       tx.meta = tx_entry.meta;
+      tx.validated = tx_entry.validated;
       transactions.push(tx);
     });
     callback(null, {

--- a/test/_payments-test.js
+++ b/test/_payments-test.js
@@ -488,7 +488,7 @@ suite('payments', function() {
       assert.equal(resp.body.hash,
         '8EA3CF4D854669007058EB45E9860611CC24FEB655895E418A5C8BC5EA901D01');
       assert.equal(resp.body.ledger, 'undefined');
-      assert.equal(resp.body.state, 'failed');
+      assert.equal(resp.body.state, 'pending');
       assert.equal(orderlist.test(), true);
       orderlist.reset();
     })
@@ -536,7 +536,7 @@ suite('payments', function() {
         assert.equal(resp.body.hash,
           '8EA3CF4D854669007058EB45E9860611CC24FEB655895E418A5C8BC5EA901D01');
         assert.equal(resp.body.ledger, 'undefined');
-        assert.equal(resp.body.state, 'failed');
+        assert.equal(resp.body.state, 'pending');
         assert.equal(orderlist.test(), true);
         orderlist.reset();
       })

--- a/test/fixtures/payments.js
+++ b/test/fixtures/payments.js
@@ -166,7 +166,7 @@ module.exports.binaryTransactionSynth = function(options) {
     hash: options.hash,
     inLedger: 348860,
     ledger_index: 348860,
-    validated: true
+    validated: options.validated
   };
 };
 
@@ -220,7 +220,8 @@ module.exports.accountTransactionsResponse = function(request, options) {
   options = options || {};
   _.defaults(options, {
     memos: [],
-    hash: module.exports.VALID_TRANSACTION_HASH
+    hash: module.exports.VALID_TRANSACTION_HASH,
+    validated: true
   });
 
   var tx = {
@@ -412,7 +413,7 @@ module.exports.accountTransactionsResponse = function(request, options) {
           ledger_index: 348860,
           tx_blob: SerializedObject.from_json(tx).to_hex(),
           meta: SerializedObject.from_json(meta).to_hex(),
-          validated: true
+          validated: options.validated
         }
       ]
     }
@@ -423,7 +424,8 @@ module.exports.transactionResponse = function(request, options) {
   options = options || {};
   _.defaults(options, {
     memos: [],
-    hash: module.exports.VALID_TRANSACTION_HASH
+    hash: module.exports.VALID_TRANSACTION_HASH,
+    validated: true
   });
 
   return JSON.stringify({
@@ -475,7 +477,8 @@ module.exports.RESTTransactionResponse = function(options) {
     toAccount: issuerAccount,
     fee: '0.00001',
     ledger: '348860',
-    client_resource_id: ''
+    client_resource_id: '',
+    state: 'validated'
   });
 
   return JSON.stringify({
@@ -540,7 +543,7 @@ module.exports.RESTTransactionResponse = function(options) {
     client_resource_id: options.client_resource_id,
     hash: options.hash,
     ledger: options.ledger,
-    state: 'validated'
+    state: options.state
   });
 };
 

--- a/test/payments-test.js
+++ b/test/payments-test.js
@@ -55,6 +55,21 @@ suite('get payments', function() {
     .end(done);
   });
 
+  test('/accounts/:account/payments/:identifier -- pending with identifier as txn hash', function(done) {
+    self.wss.once('request_tx', function(message, conn) {
+      assert.strictEqual(message.command, 'tx');
+      assert.strictEqual(message.transaction, fixtures.VALID_TRANSACTION_HASH);
+      conn.send(fixtures.transactionResponse(message, {validated: false}));
+    });
+
+    self.app
+    .get(requestPath(addresses.VALID) + '/' + fixtures.VALID_TRANSACTION_HASH)
+    .expect(testutils.checkStatus(200))
+    .expect(testutils.checkHeaders)
+    .expect(testutils.checkBody(fixtures.RESTTransactionResponse({state: 'pending'})))
+    .end(done);
+  });
+
   test('/accounts/:account/payments/:identifier -- with memos', function(done) {
     self.wss.once('request_tx', function(message, conn) {
       assert.strictEqual(message.command, 'tx');


### PR DESCRIPTION
- Previously, payments were in two states: 'validate' or 'failed', and
  'validated' status was determined incorrectly by checking the
  transaction result