### PR TITLE
[FIX] Correctly determine when to set SendMax (RLJS-272)

### DIFF
--- a/test/fixtures/addresses.js
+++ b/test/fixtures/addresses.js
@@ -1,7 +1,11 @@
+'use strict';
+
 module.exports = {
   VALID: 'r3GgMwvgvP8h4yVWvjH1dPZNvC37TjzBBE',
   ISSUER: 'r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH',
   SECRET: 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV',
   INVALID: 'rxxLy6UWsjzxsQrTATf1bwDYSaJMoTGvfY2Q',
-  COUNTERPARTY: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
+  COUNTERPARTY: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+  VALID2: 'rHrGzm86u7fwsickgTghsS9D7sUuC3VKwE',
+  ISSUER2: 'rBXMZX16zyqthrECN4AY4wxbug7335tCKh'
 };

--- a/test/unit/fixtures/rest-converter.js
+++ b/test/unit/fixtures/rest-converter.js
@@ -25,6 +25,21 @@ module.exports.paymentRestXRP = {
   }
 };
 
+module.exports.paymentRestXRPtoXRP = {
+  'source_account': addresses.VALID,
+  'source_amount': {
+    'value': '1',
+    'currency': 'XRP',
+    'issuer': ''
+  },
+  'destination_account': addresses.COUNTERPARTY,
+  'destination_amount': {
+    'value': '1',
+    'currency': 'XRP',
+    'issuer': ''
+  }
+};
+
 module.exports.paymentRestComplex = {
   'source_account': addresses.VALID,
   'source_tag': '',
@@ -118,9 +133,11 @@ module.exports.exportsPaymentRestIssuers = function(options) {
   _.defaults(options, {
     sourceAccount: addresses.VALID,
     destinationAccount: addresses.COUNTERPARTY,
-    sourceIssuer: addresses.VALID,
-    destinationIssuer: addresses.COUNTERPARTY,
-    sourceValue: '10'
+    sourceIssuer: '',
+    destinationIssuer: '',
+    sourceValue: '10',
+    destinationCurrency: 'USD',
+    sourceCurrency: 'USD'
   });
 
   return {
@@ -128,16 +145,16 @@ module.exports.exportsPaymentRestIssuers = function(options) {
     source_tag: '',
     source_amount: {
       value: options.sourceValue,
-        currency: 'USD',
+        currency: options.sourceCurrency,
         issuer: options.sourceIssuer
     },
     source_slippage: options.sourceSlippage,
-      destination_account: options.destinationAccount,
-      destination_tag: '',
-      destination_amount: {
+    destination_account: options.destinationAccount,
+    destination_tag: '',
+    destination_amount: {
       value: '10',
-        currency: 'USD',
-        issuer: options.destinationIssuer
+      currency: options.destinationCurrency,
+      issuer: options.destinationIssuer
     },
     invoice_id: '',
     paths: '[]',

--- a/test/unit/rest-converter-test.js
+++ b/test/unit/rest-converter-test.js
@@ -17,13 +17,23 @@ suite('unit - converter - Rest to Tx', function() {
     });
   });
 
-  test('convert() -- payment with XRP', function(done) {
+  test('convert() -- payment with XRP and no source amount', function(done) {
     restToTxConverter.convert(fixtures.paymentRestXRP, function(err, transaction) {
       assert.strictEqual(err, null);
       assert.deepEqual(transaction.summary(), fixtures.paymentTxXRP);
+      assert.strictEqual(transaction.tx_json.SendMax, undefined);
       done();
     });
   });
+
+  test('convert() -- payment XRP to XRP', function(done) {
+    restToTxConverter.convert(fixtures.paymentRestXRPtoXRP, function(err, transaction) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(transaction.tx_json.SendMax, undefined);
+      done();
+    });
+  });
+
 
   test('convert() -- payment with additional flags', function(done) {
     restToTxConverter.convert(fixtures.paymentRestComplex, function(err, transaction) {
@@ -46,14 +56,16 @@ suite('unit - converter - Rest to Tx', function() {
 
   test('convert() -- payment with currency that has different issuers for source and destination amount', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
-      sourceIssuer: addresses.VALID,
-      destinationIssuer: addresses.COUNTERPARTY
+      sourceAccount: addresses.VALID,
+      destinationAccount: addresses.COUNTERPARTY,
+      sourceIssuer: addresses.VALID2,
+      destinationIssuer: addresses.ISSUER2
     }), function(err, transaction) {
       assert.strictEqual(err, null);
       assert.deepEqual(transaction.tx_json.SendMax, {
         value: '10',
         currency: 'USD',
-        issuer: addresses.VALID
+        issuer: addresses.VALID2
       });
       done();
     });
@@ -61,8 +73,10 @@ suite('unit - converter - Rest to Tx', function() {
 
   test('convert() -- payment with currency that has different issuers for source and destination amount and a source_slippage of 0.1', function(done) {
     restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
-      sourceIssuer: addresses.VALID,
-      destinationIssuer: addresses.COUNTERPARTY,
+      sourceAccount: addresses.VALID,
+      destinationAccount: addresses.COUNTERPARTY,
+      sourceIssuer: addresses.VALID2,
+      destinationIssuer: addresses.ISSUER2,
       sourceSlippage: '0.1',
       sourceAmount: '10'
     }), function(err, transaction) {
@@ -70,10 +84,46 @@ suite('unit - converter - Rest to Tx', function() {
       assert.deepEqual(transaction.tx_json.SendMax, {
         value: '10.1',
         currency: 'USD',
-        issuer: addresses.VALID
+        issuer: addresses.VALID2
       });
       done();
     });
   });
+
+  test('convert() -- payment with same currency for source and destination, no issuer for source amount', function(done) {
+    restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
+      sourceIssuer: '',
+      destinationAccount: addresses.COUNTERPARTY,
+      destinationIssuer: addresses.COUNTERPARTY
+    }), function(err, transaction) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(transaction.tx_json.SendMax, undefined);
+      done();
+    });
+  });
+
+  test('convert() -- payment with same currency for source and destination, no issuer for source and destination amount', function(done) {
+    restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
+      sourceIssuer: '',
+      destinationAccount: addresses.COUNTERPARTY,
+      destinationIssuer: ''
+    }), function(err, transaction) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(transaction.tx_json.SendMax, undefined);
+      done();
+    });
+  });
+
+  test('convert() -- payment with same currency for source and destination, no issuer for destination amount', function(done) {
+    restToTxConverter.convert(fixtures.exportsPaymentRestIssuers({
+      sourceIssuer: addresses.VALID,
+      destinationAccount: addresses.COUNTERPARTY,
+      destinationIssuer: ''
+    }), function(err, transaction) {
+      assert.strictEqual(transaction.tx_json.SendMax, undefined);
+      done(err);
+    });
+  });
+
 
 });


### PR DESCRIPTION
- SendMax should not be set when the source and destination currencies
  are the same and the issuers are "any that the source is able to use
  and the destination is able to receive"

  e.g.,

```javascript
   source_amount: {
      value: '0.0003272934271954',
      currency: 'GWD',
      issuer: ''
   },
   destination_amount: {
      value: '0.0003272934271954',
      currency: 'GWD',
      issuer: 'r4p4gZaWSq8Cs1d8mn1jaGqVU1HUns1ek3'
   }
```

- SendMax documentation:
  https://ripple.com/build/transactions/#special-issuer-values-for-sendmax-and-amount