### PR TITLE
[FIX] Removing GET /notifications, handle exceptions in getTransaction

### DIFF
--- a/api/notifications.js
+++ b/api/notifications.js
@@ -169,10 +169,13 @@ function attachPreviousAndNextTransactionIdentifiers(api,
  *  @param {Notification} notification
  */
 function getNotificationHelper(api, account, identifier, topCallback) {
-  validate.address(account);
 
   function getTransaction(callback) {
-    transactions.getTransaction(api, account, identifier, {}, callback);
+    try {
+      transactions.getTransaction(api, account, identifier, {}, callback);
+    } catch(err) {
+      callback(err);
+    }
   }
 
   function checkLedger(baseTransaction, callback) {
@@ -237,6 +240,9 @@ function getNotificationHelper(api, account, identifier, topCallback) {
  *  @param {Hex-encoded String|ResourceId} req.params.identifier
  */
 function getNotification(account, identifier, urlBase, callback) {
+  validate.address(account);
+  validate.paymentIdentifier(identifier);
+
   getNotificationHelper(this, account, identifier,
       function(error, notification) {
     if (error) {

--- a/api/transactions.js
+++ b/api/transactions.js
@@ -237,13 +237,18 @@ function setTransactionBitFlags(transaction, options) {
  * @param {Transaction} transaction
  */
 function getTransaction(api, account, identifier, requestOptions, callback) {
-  assert(requestOptions);
-  assert.strictEqual(typeof requestOptions, 'object');
+
+  try {
+    assert.strictEqual(typeof requestOptions, 'object');
+
+    validate.address(account, true);
+    validate.paymentIdentifier(identifier);
+    validate.ledger(requestOptions.ledger, true);
+  } catch(err) {
+    return callback(err);
+  }
 
   var options = { };
-  validate.address(account, true);
-  validate.paymentIdentifier(identifier);
-  validate.ledger(requestOptions.ledger, true);
 
   if (validator.isValid(identifier, 'Hash256')) {
     options.hash = identifier;

--- a/server/routes.js
+++ b/server/routes.js
@@ -243,7 +243,6 @@ module.exports = {
     '/accounts/:account/orders': makeMiddleware(getOrders),
     '/accounts/:account/order_book/:base/:counter': makeMiddleware(getOrderBook),
     '/accounts/:account/orders/:identifier': makeMiddleware(getOrder),
-    '/accounts/:account/notifications': makeMiddleware(getNotification),
     '/accounts/:account/notifications/:identifier': makeMiddleware(getNotification),
     '/accounts/:account/balances': makeMiddleware(getBalances),
     '/accounts/:account/settings': makeMiddleware(getSettings),


### PR DESCRIPTION
- getTransaction was not handling exceptions thrown by the validation
  calls

- Example:

```
2015-04-13T22:54:51.183Z - error: uncaughtException: Parameter missing:
paymentIdentifier
{ date: 'Mon Apr 13 2015 22:54:51 GMT+0000 (UTC)',
```