### PR TITLE
Use npm-shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,99 +1,83 @@
 {
   "name": "ripple-rest",
   "version": "1.6.0-rc6",
+  "npm-shrinkwrap-version": "5.3.0",
+  "node-version": "v0.10.38",
   "dependencies": {
     "async": {
       "version": "0.2.10",
-      "from": "async@>=0.2.9 <0.3.0",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
     },
     "bignumber.js": {
       "version": "1.5.0",
-      "from": "bignumber.js@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.5.0.tgz"
     },
     "bluebird": {
       "version": "2.9.12",
-      "from": "bluebird@>=2.3.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.12.tgz"
     },
     "body-parser": {
       "version": "1.12.0",
-      "from": "body-parser@>=1.7.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.0.tgz",
       "dependencies": {
         "bytes": {
           "version": "1.0.0",
-          "from": "bytes@1.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
         },
         "content-type": {
           "version": "1.0.1",
-          "from": "content-type@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "debug": {
           "version": "2.1.1",
-          "from": "debug@>=2.1.1 <2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.0",
-          "from": "depd@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "iconv-lite": {
           "version": "0.4.7",
-          "from": "iconv-lite@0.4.7",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
         },
         "on-finished": {
           "version": "2.2.0",
-          "from": "on-finished@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
-              "from": "ee-first@1.1.0",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
         },
         "qs": {
           "version": "2.3.3",
-          "from": "qs@2.3.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "raw-body": {
           "version": "1.3.3",
-          "from": "raw-body@1.3.3",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.3.tgz"
         },
         "type-is": {
           "version": "1.6.0",
-          "from": "type-is@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.0.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@>=2.0.9 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
@@ -104,412 +88,342 @@
     },
     "compression": {
       "version": "1.4.1",
-      "from": "compression@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.4.1.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.4",
-          "from": "accepts@>=1.2.4 <1.3.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.4.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@>=2.0.9 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.5.1",
-              "from": "negotiator@0.5.1",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
             }
           }
         },
         "bytes": {
           "version": "1.0.0",
-          "from": "bytes@1.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
         },
         "compressible": {
           "version": "2.0.2",
-          "from": "compressible@>=2.0.2 <2.1.0",
           "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.7.0",
-              "from": "mime-db@>=1.1.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
             }
           }
         },
         "debug": {
           "version": "2.1.1",
-          "from": "debug@>=2.1.1 <2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "on-headers": {
           "version": "1.0.0",
-          "from": "on-headers@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
         },
         "vary": {
           "version": "1.0.0",
-          "from": "vary@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
         }
       }
     },
     "express": {
       "version": "4.12.0",
-      "from": "express@>=4.8.7 <5.0.0",
       "resolved": "https://registry.npmjs.org/express/-/express-4.12.0.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.4",
-          "from": "accepts@>=1.2.4 <1.3.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.4.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@>=2.0.9 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.5.1",
-              "from": "negotiator@0.5.1",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
             }
           }
         },
         "content-disposition": {
           "version": "0.5.0",
-          "from": "content-disposition@0.5.0",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
         },
         "content-type": {
           "version": "1.0.1",
-          "from": "content-type@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+        },
+        "cookie": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.1.1",
-          "from": "debug@>=2.1.1 <2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.0",
-          "from": "depd@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "escape-html": {
           "version": "1.0.1",
-          "from": "escape-html@1.0.1",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
           "version": "1.5.1",
-          "from": "etag@>=1.5.1 <1.6.0",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
           "dependencies": {
             "crc": {
               "version": "3.2.1",
-              "from": "crc@3.2.1",
               "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
             }
           }
         },
         "finalhandler": {
           "version": "0.3.3",
-          "from": "finalhandler@0.3.3",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz"
         },
         "fresh": {
           "version": "0.2.4",
-          "from": "fresh@0.2.4",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+        },
+        "merge-descriptors": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
         },
         "methods": {
           "version": "1.1.1",
-          "from": "methods@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
         },
         "on-finished": {
           "version": "2.2.0",
-          "from": "on-finished@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
-              "from": "ee-first@1.1.0",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.0",
-          "from": "parseurl@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.3",
-          "from": "path-to-regexp@0.1.3",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
         },
         "proxy-addr": {
           "version": "1.0.6",
-          "from": "proxy-addr@>=1.0.6 <1.1.0",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.6.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "forwarded@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
               "version": "0.1.8",
-              "from": "ipaddr.js@0.1.8",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.8.tgz"
             }
           }
         },
         "qs": {
           "version": "2.3.3",
-          "from": "qs@2.3.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "range-parser": {
           "version": "1.0.2",
-          "from": "range-parser@>=1.0.2 <1.1.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
         },
         "send": {
           "version": "0.12.1",
-          "from": "send@0.12.1",
           "resolved": "https://registry.npmjs.org/send/-/send-0.12.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.3",
-              "from": "destroy@1.0.3",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@1.3.4",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.0",
-              "from": "ms@0.7.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.9.1",
-          "from": "serve-static@>=1.9.1 <1.10.0",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.1.tgz"
         },
         "type-is": {
           "version": "1.6.0",
-          "from": "type-is@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.0.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@>=2.0.9 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
             }
           }
         },
-        "vary": {
-          "version": "1.0.0",
-          "from": "vary@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
-        },
-        "cookie": {
-          "version": "0.1.2",
-          "from": "cookie@0.1.2",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
-        },
-        "merge-descriptors": {
-          "version": "0.0.2",
-          "from": "merge-descriptors@0.0.2",
-          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
-        },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "utils-merge@1.0.0",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        },
+        "vary": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
         }
       }
     },
     "jayschema": {
       "version": "0.3.1",
-      "from": "jayschema@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/jayschema/-/jayschema-0.3.1.tgz",
       "dependencies": {
         "when": {
           "version": "3.4.6",
-          "from": "when@>=3.4.6 <3.5.0",
           "resolved": "https://registry.npmjs.org/when/-/when-3.4.6.tgz"
         }
       }
     },
     "jayschema-error-messages": {
       "version": "1.0.3",
-      "from": "jayschema-error-messages@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jayschema-error-messages/-/jayschema-error-messages-1.0.3.tgz"
     },
     "knex": {
       "version": "0.7.6",
-      "from": "knex@>=0.7.6 <0.8.0",
       "resolved": "https://registry.npmjs.org/knex/-/knex-0.7.6.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "commander": {
           "version": "2.8.0",
-          "from": "commander@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.0.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "generic-pool-redux": {
           "version": "0.1.0",
-          "from": "generic-pool-redux@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/generic-pool-redux/-/generic-pool-redux-0.1.0.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "interpret": {
           "version": "0.3.10",
-          "from": "interpret@>=0.3.2 <0.4.0",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.10.tgz"
         },
         "liftoff": {
           "version": "0.13.6",
-          "from": "liftoff@>=0.13.2 <0.14.0",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-0.13.6.tgz",
           "dependencies": {
+            "extend": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz"
+            },
             "findup-sync": {
               "version": "0.1.3",
-              "from": "findup-sync@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.9 <3.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.1",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz"
+                          "version": "2.5.2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -518,75 +432,58 @@
                 }
               }
             },
-            "resolve": {
-              "version": "1.0.0",
-              "from": "resolve@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz"
-            },
-            "extend": {
-              "version": "1.3.0",
-              "from": "extend@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz"
-            },
             "flagged-respawn": {
               "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+            },
+            "resolve": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.0 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "minimist": {
           "version": "1.1.1",
-          "from": "minimist@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.12 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             }
           }
         },
         "tildify": {
           "version": "1.0.0",
-          "from": "tildify@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             }
           }
@@ -594,45 +491,37 @@
       }
     },
     "lodash": {
-      "version": "3.7.0",
-      "from": "lodash@>=3.6.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
     },
     "morgan": {
       "version": "1.5.1",
-      "from": "morgan@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.1.tgz",
       "dependencies": {
         "basic-auth": {
           "version": "1.0.0",
-          "from": "basic-auth@1.0.0",
           "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
         },
         "debug": {
           "version": "2.1.1",
-          "from": "debug@>=2.1.1 <2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.0",
-          "from": "depd@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "on-finished": {
           "version": "2.2.0",
-          "from": "on-finished@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
-              "from": "ee-first@1.1.0",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
@@ -641,33 +530,27 @@
     },
     "nconf": {
       "version": "0.6.9",
-      "from": "nconf@>=0.6.9 <0.7.0",
       "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.6.9.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.9",
-          "from": "async@0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
         },
         "ini": {
           "version": "1.3.3",
-          "from": "ini@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
         },
         "optimist": {
           "version": "0.6.0",
-          "from": "optimist@0.6.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         }
@@ -675,83 +558,68 @@
     },
     "node-uuid": {
       "version": "1.4.2",
-      "from": "node-uuid@>=1.4.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
     },
     "ripple-lib": {
       "version": "0.12.4-rc1",
-      "from": "ripple-lib@>=0.12.4-rc1 <0.13.0",
+      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-0.12.4-rc1.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "bignumber.js": {
           "version": "2.0.7",
-          "from": "bignumber.js@>=2.0.3 <3.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.0.7.tgz"
         },
         "extend": {
           "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
         },
         "lru-cache": {
           "version": "2.5.2",
-          "from": "lru-cache@>=2.5.0 <2.6.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
         },
         "ripple-wallet-generator": {
           "version": "1.0.3",
-          "from": "ripple-wallet-generator@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/ripple-wallet-generator/-/ripple-wallet-generator-1.0.3.tgz"
         },
         "ws": {
           "version": "0.7.1",
-          "from": "ws@>=0.7.1 <0.8.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.1.tgz",
           "dependencies": {
-            "options": {
-              "version": "0.0.6",
-              "from": "options@>=0.0.5",
-              "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-            },
-            "ultron": {
-              "version": "1.0.1",
-              "from": "ultron@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
-            },
             "bufferutil": {
               "version": "1.0.1",
-              "from": "bufferutil@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.0.1.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
-                  "from": "bindings@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
                   "version": "1.6.2",
-                  "from": "nan@>=1.6.0 <1.7.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
                 }
               }
             },
+            "options": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+            },
+            "ultron": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+            },
             "utf-8-validate": {
               "version": "1.0.1",
-              "from": "utf-8-validate@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.0.1.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
-                  "from": "bindings@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
                   "version": "1.6.2",
-                  "from": "nan@>=1.6.0 <1.7.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
                 }
               }
@@ -762,89 +630,109 @@
     },
     "ripple-lib-transactionparser": {
       "version": "0.3.2",
-      "from": "ripple-lib-transactionparser@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/ripple-lib-transactionparser/-/ripple-lib-transactionparser-0.3.2.tgz",
       "dependencies": {
         "bignumber.js": {
           "version": "1.4.1",
-          "from": "bignumber.js@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.1.tgz"
         }
       }
     },
     "sqlite3": {
       "version": "3.0.5",
-      "from": "sqlite3@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.0.5.tgz",
       "dependencies": {
         "nan": {
           "version": "1.6.2",
-          "from": "nan@>=1.6.2 <1.7.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
         },
         "node-pre-gyp": {
           "version": "0.6.2",
-          "from": "node-pre-gyp@~0.6.2",
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.2.tgz",
           "dependencies": {
+            "mkdirp": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
             "nopt": {
               "version": "3.0.1",
-              "from": "nopt@~3.0.1",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.5",
-                  "from": "abbrev@1",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "0.1.1",
-              "from": "npmlog@~0.1.1",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "from": "ansi@~0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                }
+              }
+            },
+            "rc": {
+              "version": "0.5.5",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.2.11",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                },
+                "ini": {
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                 }
               }
             },
             "request": {
               "version": "2.51.0",
-              "from": "request@2.x",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
                 "bl": {
                   "version": "0.9.3",
-                  "from": "bl@~0.9.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -852,347 +740,249 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "caseless@~0.8.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@~0.9.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.0.7",
-                      "from": "mime-types@~2.0.3",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.5.0",
-                          "from": "mime-db@~1.5.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
                         }
                       }
                     }
                   }
                 },
-                "json-stringify-safe": {
-                  "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-                },
-                "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "node-uuid@~1.4.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-                },
-                "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "tunnel-agent@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-                },
-                "tough-cookie": {
-                  "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                "hawk": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
-                    "punycode": {
-                      "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    "boom": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "hoek": {
+                      "version": "0.9.1",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@~0.10.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "oauth-sign@~0.5.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
-                "hawk": {
-                  "version": "1.1.1",
-                  "from": "hawk@1.1.1",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "0.9.1",
-                      "from": "hoek@0.9.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                    },
-                    "boom": {
-                      "version": "0.4.2",
-                      "from": "boom@0.4.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "cryptiles@0.2.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                    },
-                    "sntp": {
-                      "version": "0.2.4",
-                      "from": "sntp@0.2.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                "qs": {
+                  "version": "2.3.3",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    "punycode": {
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 }
               }
             },
+            "rimraf": {
+              "version": "2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
             "semver": {
               "version": "4.2.0",
-              "from": "semver@~4.2.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.0.tgz"
             },
             "tar": {
               "version": "1.0.3",
-              "from": "tar@~1.0.2",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.7",
-                  "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                 },
                 "fstream": {
                   "version": "1.0.3",
-                  "from": "fstream@^1.0.2",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.3.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "3.0.5",
-                      "from": "graceful-fs@3",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "tar-pack": {
               "version": "2.0.0",
-              "from": "tar-pack@~2.0.0",
               "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
               "dependencies": {
-                "uid-number": {
-                  "version": "0.0.3",
-                  "from": "uid-number@0.0.3",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-                },
-                "once": {
-                  "version": "1.1.1",
-                  "from": "once@~1.1.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-                },
                 "debug": {
                   "version": "0.7.4",
-                  "from": "debug@~0.7.2",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                 },
                 "fstream": {
                   "version": "0.1.31",
-                  "from": "fstream@~0.1.22",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "3.0.5",
-                      "from": "graceful-fs@3",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "tar": {
-                  "version": "0.1.20",
-                  "from": "tar@~0.1.17",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
-                  "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.7",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "fstream-ignore": {
                   "version": "0.0.7",
-                  "from": "fstream-ignore@0.0.7",
                   "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
                   "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@~0.2.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.2",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@1.2",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                },
+                "once": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "tar": {
+                  "version": "0.1.20",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.7",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "uid-number": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
                 }
               }
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "from": "mkdirp@~0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "rc": {
-              "version": "0.5.5",
-              "from": "rc@~0.5.1",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "from": "minimist@~0.0.7",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                },
-                "deep-extend": {
-                  "version": "0.2.11",
-                  "from": "deep-extend@~0.2.5",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-                },
-                "strip-json-comments": {
-                  "version": "0.1.3",
-                  "from": "strip-json-comments@0.1.x",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                },
-                "ini": {
-                  "version": "1.3.2",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.2.tgz"
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@~2.2.8",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
         }
@@ -1200,157 +990,128 @@
     },
     "supertest": {
       "version": "0.13.0",
-      "from": "supertest@>=0.13.0 <0.14.0",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-0.13.0.tgz",
       "dependencies": {
+        "methods": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.0.tgz"
+        },
         "superagent": {
           "version": "0.18.0",
-          "from": "superagent@0.18.0",
           "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.18.0.tgz",
           "dependencies": {
-            "qs": {
-              "version": "0.6.6",
-              "from": "qs@0.6.6",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
-            },
-            "formidable": {
-              "version": "1.0.14",
-              "from": "formidable@1.0.14",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
-            },
-            "mime": {
-              "version": "1.2.5",
-              "from": "mime@1.2.5",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz"
-            },
             "component-emitter": {
               "version": "1.1.2",
-              "from": "component-emitter@1.1.2",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-            },
-            "methods": {
-              "version": "0.0.1",
-              "from": "methods@0.0.1",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
             },
             "cookiejar": {
               "version": "1.3.2",
-              "from": "cookiejar@1.3.2",
               "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.2.tgz"
             },
             "debug": {
               "version": "0.7.4",
-              "from": "debug@>=0.7.2 <0.8.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            },
-            "reduce-component": {
-              "version": "1.0.1",
-              "from": "reduce-component@1.0.1",
-              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
             },
             "extend": {
               "version": "1.2.1",
-              "from": "extend@>=1.2.1 <1.3.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
             },
             "form-data": {
               "version": "0.1.2",
-              "from": "form-data@0.1.2",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.11 <1.3.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 }
               }
             },
+            "formidable": {
+              "version": "1.0.14",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+            },
+            "methods": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+            },
+            "mime": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            },
             "readable-stream": {
               "version": "1.0.27-1",
-              "from": "readable-stream@1.0.27-1",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
+            },
+            "reduce-component": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
             }
           }
-        },
-        "methods": {
-          "version": "1.0.0",
-          "from": "methods@1.0.0",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.0.tgz"
         }
       }
     },
     "winston": {
       "version": "1.0.0",
-      "from": "winston@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-1.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "colors": {
           "version": "1.0.3",
-          "from": "colors@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
         },
         "cycle": {
           "version": "1.0.3",
-          "from": "cycle@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
         },
         "eyes": {
           "version": "0.1.8",
-          "from": "eyes@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "pkginfo": {
           "version": "0.3.0",
-          "from": "pkginfo@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
         },
         "stack-trace": {
           "version": "0.0.9",
-          "from": "stack-trace@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "coveralls": "^2.10.0",
     "istanbul": "^0.2.10",
     "mocha": "^2.1.0",
+    "npm-shrinkwrap": "^5.3",
     "require-directory": "^1.2.0",
     "sinon": "~1.10.0",
     "sinon-chai": "^2.5.0",


### PR DESCRIPTION
Why?

- Consistently set a `resolved` field and reduce diff churn
- Local correctness for edge cases not handled by npm

https://github.com/uber/npm-shrinkwrap#motivation

Setup:

```
   $ npm install
```

Or, make it available globally

```
   $ npm install -g npm-shrinkwrap
```

Anytime dependencies are changed

```
   $ ./node_modules/.bin/npm-shrinkwrap

   # Human readable diff
   $ ./node_modules/.bin/npm-shrinkwrap diff master HEAD
   $ ./node_modules/.bin/npm-shrinkwrap diff HEAD npm-shrinkwrap.json --short
```

See: https://github.com/uber/npm-shrinkwrap